### PR TITLE
Render layered avatar sprites with eased movement

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -494,21 +494,21 @@ When implementing, **Codex should**:
 
 ---
 
-## 24) Progress Snapshot — 2025-09-25
+## 24) Progress Snapshot — 2025-09-26
 
 - ✅ Client grid renderer + chrome are live with the spec-mandated blocking reconnect overlay driven by a reusable `useRealtimeConnection` hook.
 - ✅ Fastify Socket.IO endpoint now validates HS256 JWTs issued from `/auth/login`, returns a development room snapshot inside `auth:ok`, closes idle sockets after the 30 s heartbeat window, and accepts `move` envelopes with `move:ok` / `move:err` replies plus `room:occupant_moved` broadcasts.
 - ✅ Shared schema package now covers the core envelope plus development room/move payloads so the client and server validate optimistic movement and room snapshots against the same definitions.
 - ✅ Client dev workflow automatically rebuilds `@bitby/schemas` before Vite starts (with a dedicated `pnpm --filter @bitby/schemas dev` watcher) so the workspace no longer crashes on fresh clones when resolving shared envelopes.
-- ✅ React client performs the `/auth/login` flow automatically, surfaces heartbeat-driven reconnect status, renders development avatar sprites, and keeps the stage chrome deterministic while reconciling optimistic moves with authoritative acks.
-- ✅ Strict Mode lifecycle handling in `useRealtimeConnection` now resets its disposal guard and treats intentional `AbortController` cancellations as benign, so `/auth/login` no longer aborts under automation. Latest overlay-free screenshot: `browser:/invocations/xjwvubss/artifacts/artifacts/bitby-connected.png`.
+- ✅ React client performs the `/auth/login` flow automatically, surfaces heartbeat-driven reconnect status, draws the development room background, foot-anchors placeholder avatar PNGs with a local highlight, and keeps optimistic moves visually aligned via eased interpolation while authoritative acks reconcile state.
+- ✅ Strict Mode lifecycle handling in `useRealtimeConnection` now resets its disposal guard and treats intentional `AbortController` cancellations as benign, so `/auth/login` no longer aborts under automation. Latest overlay-free screenshot: `browser:/invocations/hsmymagx/artifacts/artifacts/bitby-connected.png`.
 
 ### Immediate Next Focus
 
-1. Layer sprite z-ordering, animation timing, and placeholder assets on top of the optimistic movement loop so the development avatars respect the Master Spec compositing rules.
-2. Stand up Postgres/Redis (local Docker) and wire the server to persist/load room state and broadcast deltas beyond the in-memory development authority.
+1. Stand up Postgres/Redis (local Docker) and wire the server to persist/load room state and broadcast deltas beyond the in-memory development authority.
+2. Implement chat and richer presence broadcast loops that hydrate the room snapshot, drive client updates, and render typing bubbles/right-panel logs beyond the current fixtures.
 3. Extend `@bitby/schemas` with additional realtime/REST definitions (chat, error envelopes, presence) so the server/client no longer rely on ad-hoc payload shapes.
-4. Implement chat and richer presence broadcast loops that hydrate the room snapshot and drive client state updates beyond the current fixtures.
+4. Bring up Postgres/Redis migrations, data seeds, and automated test harnesses (unit/integration/visual) that exercise the heartbeat + reconnect flow.
 5. Decide how to handle the `[realtime]` `console.debug` statements before production builds (demote, gate, or remove).
 
 **End of AGENT.md**

--- a/packages/client/src/canvas/GridCanvas.tsx
+++ b/packages/client/src/canvas/GridCanvas.tsx
@@ -2,33 +2,61 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from './constants';
 import { buildGridDefinition, createTileKey, findTileAtPoint } from './geometry';
 import type { GridDefinition, GridTile } from './types';
+import devRoomUrl from '../assets/rooms/dev_room.png';
+import avatar1Url from '../assets/avatars/avatar1.png';
+import avatar2Url from '../assets/avatars/avatar2.png';
 
-interface CanvasOccupant {
+type CanvasOccupant = {
   id: string;
   username: string;
   roles: string[];
   position: { x: number; y: number };
-}
+};
 
-interface TileFlag {
+type TileFlag = {
   x: number;
   y: number;
   locked: boolean;
   noPickup: boolean;
-}
+};
 
-interface GridCanvasProps {
+type GridCanvasProps = {
   occupants: CanvasOccupant[];
   tileFlags: TileFlag[];
   pendingMoveTarget: { x: number; y: number } | null;
   onTileClick?: (tile: GridTile) => void;
   localOccupantId?: string | null;
-}
+};
 
-interface PointerPosition {
+type PointerPosition = {
   x: number;
   y: number;
-}
+};
+
+type SpriteAssets = {
+  room: HTMLImageElement | null;
+  avatars: HTMLImageElement[];
+};
+
+type OccupantRenderState = {
+  id: string;
+  username: string;
+  gridX: number;
+  gridY: number;
+  tileWidth: number;
+  baseX: number;
+  baseY: number;
+  currentX: number;
+  currentY: number;
+  startX: number;
+  startY: number;
+  targetX: number;
+  targetY: number;
+  startTime: number;
+  duration: number;
+  avatarIndex: number;
+  isLocal: boolean;
+};
 
 const tileStroke = 'rgba(126, 178, 229, 0.52)';
 const hoveredStroke = 'rgba(122, 209, 255, 0.9)';
@@ -37,10 +65,26 @@ const lockedFill = 'rgba(209, 71, 94, 0.24)';
 const noPickupFill = 'rgba(255, 200, 99, 0.2)';
 const centerDot = '#5ec9ff';
 const hoveredCenterDot = '#e8f6ff';
-const localOccupantFill = '#ffd166';
-const localOccupantAccent = '#f49d37';
-const remoteOccupantFill = '#5fa8ff';
-const remoteOccupantAccent = '#2c6dcf';
+const localGroundHighlight = 'rgba(244, 157, 55, 0.6)';
+const avatarShadow = 'rgba(0, 0, 0, 0.28)';
+const usernameFill = 'rgba(20, 35, 54, 0.55)';
+
+const AVATAR_SOURCES: string[] = [avatar1Url, avatar2Url];
+const MOVEMENT_DURATION_MS = 220;
+const FOOT_OFFSET = 6;
+const USERNAME_OFFSET = 10;
+const FALLBACK_AVATAR_WIDTH = 48;
+const FALLBACK_AVATAR_HEIGHT = 90;
+
+const loadImage = async (source: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = source;
+  });
+
+const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
 
 const prepareContext = (canvas: HTMLCanvasElement): CanvasRenderingContext2D | null => {
   const context = canvas.getContext('2d');
@@ -65,8 +109,24 @@ const prepareContext = (canvas: HTMLCanvasElement): CanvasRenderingContext2D | n
   return context;
 };
 
-const drawBackground = (context: CanvasRenderingContext2D): void => {
+const drawBackground = (
+  context: CanvasRenderingContext2D,
+  assets: SpriteAssets | null,
+): void => {
   context.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+  if (assets?.room) {
+    context.drawImage(assets.room, 0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  }
+};
+
+const traceDiamond = (context: CanvasRenderingContext2D, tile: GridTile): void => {
+  context.beginPath();
+  context.moveTo(tile.centerX, tile.screenY);
+  context.lineTo(tile.screenX + tile.width, tile.centerY);
+  context.lineTo(tile.centerX, tile.screenY + tile.height);
+  context.lineTo(tile.screenX, tile.centerY);
+  context.closePath();
 };
 
 const drawTile = (
@@ -74,34 +134,26 @@ const drawTile = (
   tile: GridTile,
   options: { hovered: boolean; locked: boolean; pending: boolean; noPickup: boolean },
 ): void => {
-  const centerX = tile.centerX;
-  const centerY = tile.centerY;
-
-  const traceDiamond = () => {
-    context.beginPath();
-    context.moveTo(centerX, tile.screenY);
-    context.lineTo(tile.screenX + tile.width, centerY);
-    context.lineTo(centerX, tile.screenY + tile.height);
-    context.lineTo(tile.screenX, centerY);
-    context.closePath();
-  };
-
   context.save();
 
-  traceDiamond();
-  if (options.locked || options.noPickup) {
-    context.fillStyle = options.locked ? lockedFill : noPickupFill;
+  traceDiamond(context, tile);
+  if (options.locked) {
+    context.fillStyle = lockedFill;
     context.fill();
+    traceDiamond(context, tile);
+  } else if (options.noPickup) {
+    context.fillStyle = noPickupFill;
+    context.fill();
+    traceDiamond(context, tile);
   }
 
-  traceDiamond();
   context.setLineDash([]);
   context.lineWidth = options.hovered ? 2 : 1;
   context.strokeStyle = options.hovered ? hoveredStroke : tileStroke;
   context.stroke();
 
   if (options.pending) {
-    traceDiamond();
+    traceDiamond(context, tile);
     context.setLineDash([6, 4]);
     context.lineWidth = 2;
     context.strokeStyle = pendingStroke;
@@ -112,68 +164,115 @@ const drawTile = (
 
   context.beginPath();
   context.fillStyle = options.hovered ? hoveredCenterDot : centerDot;
-  context.arc(centerX, centerY, options.hovered ? 3 : 2, 0, Math.PI * 2);
+  context.arc(tile.centerX, tile.centerY, options.hovered ? 3 : 2, 0, Math.PI * 2);
   context.fill();
 };
 
-const renderGrid = (
+const drawUsername = (
   context: CanvasRenderingContext2D,
-  grid: GridDefinition,
-  hoveredTile: GridTile | null,
-  lockedTiles: Set<string>,
-  noPickupTiles: Set<string>,
-  pendingTileKey: string | null,
-  occupants: Array<{ tile: GridTile; occupant: CanvasOccupant }>,
-  localOccupantId: string | null,
+  sprite: OccupantRenderState,
+  avatarHeight: number,
 ): void => {
-  drawBackground(context);
+  const labelY = sprite.currentY - avatarHeight - USERNAME_OFFSET;
 
-  for (const tile of grid.tiles) {
-    drawTile(context, tile, {
-      hovered: hoveredTile?.key === tile.key,
-      locked: lockedTiles.has(tile.key),
-      noPickup: noPickupTiles.has(tile.key) && !lockedTiles.has(tile.key),
-      pending: pendingTileKey === tile.key,
-    });
-  }
+  context.save();
+  context.font = '14px "Inter", "Segoe UI", sans-serif';
+  context.textAlign = 'center';
+  context.textBaseline = 'bottom';
+  context.fillStyle = usernameFill;
+  context.fillText(sprite.username, sprite.currentX, labelY);
+  context.restore();
+};
 
-  for (const sprite of occupants) {
-    const isLocal = sprite.occupant.id === localOccupantId;
-    const baseX = sprite.tile.centerX;
-    const baseY = sprite.tile.screenY + sprite.tile.height - 6;
+const drawOccupant = (
+  context: CanvasRenderingContext2D,
+  sprite: OccupantRenderState,
+  assets: SpriteAssets | null,
+): void => {
+  const avatarImages = assets?.avatars ?? [];
+  const avatarImage = avatarImages[sprite.avatarIndex] ?? null;
+  const avatarWidth = avatarImage?.width ?? FALLBACK_AVATAR_WIDTH;
+  const avatarHeight = avatarImage?.height ?? FALLBACK_AVATAR_HEIGHT;
+  const drawX = sprite.currentX - avatarWidth / 2;
+  const drawY = sprite.currentY - avatarHeight;
 
+  drawUsername(context, sprite, avatarHeight);
+
+  context.save();
+  context.fillStyle = avatarShadow;
+  context.beginPath();
+  context.ellipse(sprite.currentX, sprite.baseY - 2, sprite.tileWidth * 0.32, 10, 0, 0, Math.PI * 2);
+  context.fill();
+  context.restore();
+
+  if (sprite.isLocal) {
     context.save();
-
-    context.fillStyle = 'rgba(0, 0, 0, 0.28)';
+    context.strokeStyle = localGroundHighlight;
+    context.lineWidth = 3;
     context.beginPath();
-    context.ellipse(baseX, baseY, sprite.tile.width * 0.3, 10, 0, 0, Math.PI * 2);
-    context.fill();
-
-    const bodyWidth = 28;
-    const bodyHeight = 50;
-    const bodyTop = baseY - bodyHeight;
-    const radius = 12;
-
-    context.fillStyle = isLocal ? localOccupantFill : remoteOccupantFill;
-    context.beginPath();
-    context.moveTo(baseX - bodyWidth / 2, bodyTop + radius);
-    context.quadraticCurveTo(baseX - bodyWidth / 2, bodyTop, baseX - bodyWidth / 2 + radius, bodyTop);
-    context.lineTo(baseX + bodyWidth / 2 - radius, bodyTop);
-    context.quadraticCurveTo(baseX + bodyWidth / 2, bodyTop, baseX + bodyWidth / 2, bodyTop + radius);
-    context.lineTo(baseX + bodyWidth / 2, baseY - radius * 0.6);
-    context.quadraticCurveTo(baseX + bodyWidth / 2, baseY, baseX + bodyWidth / 2 - radius, baseY);
-    context.lineTo(baseX - bodyWidth / 2 + radius, baseY);
-    context.quadraticCurveTo(baseX - bodyWidth / 2, baseY, baseX - bodyWidth / 2, baseY - radius * 0.6);
-    context.closePath();
-    context.fill();
-
-    context.fillStyle = isLocal ? localOccupantAccent : remoteOccupantAccent;
-    context.beginPath();
-    context.arc(baseX, bodyTop, 14, 0, Math.PI * 2);
-    context.fill();
-
+    context.ellipse(sprite.currentX, sprite.baseY - 2, sprite.tileWidth * 0.38, 12, 0, 0, Math.PI * 2);
+    context.stroke();
     context.restore();
   }
+
+  if (avatarImage) {
+    context.drawImage(avatarImage, drawX, drawY, avatarWidth, avatarHeight);
+    return;
+  }
+
+  context.save();
+  context.fillStyle = sprite.isLocal ? '#ffd166' : '#5fa8ff';
+  context.beginPath();
+  context.moveTo(drawX, drawY + 12);
+  context.lineTo(drawX + avatarWidth, drawY + 12);
+  context.lineTo(sprite.currentX + avatarWidth * 0.35 - avatarWidth / 2, sprite.currentY);
+  context.lineTo(sprite.currentX - avatarWidth * 0.35 + avatarWidth / 2, sprite.currentY);
+  context.closePath();
+  context.fill();
+  context.restore();
+};
+
+const updateSpritePositions = (
+  sprites: Map<string, OccupantRenderState>,
+  now: number,
+): void => {
+  for (const sprite of sprites.values()) {
+    if (sprite.duration <= 0) {
+      sprite.currentX = sprite.targetX;
+      sprite.currentY = sprite.targetY;
+      continue;
+    }
+
+    const elapsed = now - sprite.startTime;
+    const progress = Math.min(Math.max(elapsed / sprite.duration, 0), 1);
+    const eased = easeOutCubic(progress);
+
+    sprite.currentX = sprite.startX + (sprite.targetX - sprite.startX) * eased;
+    sprite.currentY = sprite.startY + (sprite.targetY - sprite.startY) * eased;
+
+    if (progress >= 1) {
+      sprite.duration = 0;
+      sprite.currentX = sprite.targetX;
+      sprite.currentY = sprite.targetY;
+    }
+  }
+};
+
+const getAvatarVariantIndex = (occupant: CanvasOccupant): number => {
+  if (occupant.roles.includes('npc')) {
+    return AVATAR_SOURCES.length > 1 ? 1 : 0;
+  }
+
+  if (AVATAR_SOURCES.length === 0) {
+    return 0;
+  }
+
+  let hash = 0;
+  for (let index = 0; index < occupant.id.length; index += 1) {
+    hash = (hash * 31 + occupant.id.charCodeAt(index)) | 0;
+  }
+
+  return Math.abs(hash) % AVATAR_SOURCES.length;
 };
 
 const formatCoordinate = (value: number): string => value.toFixed(0);
@@ -186,9 +285,57 @@ const GridCanvas = ({
   localOccupantId = null,
 }: GridCanvasProps): JSX.Element => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const grid = useMemo(() => buildGridDefinition(), []);
+  const grid = useMemo<GridDefinition>(() => buildGridDefinition(), []);
   const [hoveredTile, setHoveredTile] = useState<GridTile | null>(null);
+  const hoveredTileRef = useRef<GridTile | null>(null);
   const [pointer, setPointer] = useState<PointerPosition | null>(null);
+  const [assets, setAssets] = useState<SpriteAssets | null>(null);
+  const assetsRef = useRef<SpriteAssets | null>(null);
+  const occupantSpritesRef = useRef<Map<string, OccupantRenderState>>(new Map());
+  const animationFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    assetsRef.current = assets;
+  }, [assets]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadAssets = async (): Promise<void> => {
+      try {
+        const [roomImage, ...avatarImages] = await Promise.all([
+          loadImage(devRoomUrl),
+          ...AVATAR_SOURCES.map((source) => loadImage(source)),
+        ]);
+
+        if (isMounted) {
+          setAssets({ room: roomImage, avatars: avatarImages });
+        }
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.warn('Failed to load canvas assets', error);
+        }
+        if (isMounted) {
+          setAssets({ room: null, avatars: [] });
+        }
+      }
+    };
+
+    loadAssets().catch(() => {
+      if (isMounted) {
+        setAssets({ room: null, avatars: [] });
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    hoveredTileRef.current = hoveredTile;
+  }, [hoveredTile]);
+
 
   const lockedTileKeys = useMemo(() => {
     const keys = new Set<string>();
@@ -217,17 +364,97 @@ const GridCanvas = ({
     return createTileKey(pendingMoveTarget.x, pendingMoveTarget.y);
   }, [pendingMoveTarget]);
 
-  const occupantSprites = useMemo(() =>
-    occupants
-      .map((occupant) => {
-        const tile = grid.tileMap.get(createTileKey(occupant.position.x, occupant.position.y));
-        if (!tile) {
-          return null;
-        }
-        return { tile, occupant };
-      })
-      .filter((value): value is { tile: GridTile; occupant: CanvasOccupant } => value !== null),
-  [grid, occupants]);
+  const lockedTilesRef = useRef(lockedTileKeys);
+  const noPickupTilesRef = useRef(noPickupTileKeys);
+  const pendingTileKeyRef = useRef<string | null>(pendingTileKey);
+
+  useEffect(() => {
+    lockedTilesRef.current = lockedTileKeys;
+  }, [lockedTileKeys]);
+
+  useEffect(() => {
+    noPickupTilesRef.current = noPickupTileKeys;
+  }, [noPickupTileKeys]);
+
+  useEffect(() => {
+    pendingTileKeyRef.current = pendingTileKey;
+  }, [pendingTileKey]);
+
+  const occupantTargets = useMemo(() => {
+    const entries = new Map<string, { occupant: CanvasOccupant; tile: GridTile }>();
+    for (const occupant of occupants) {
+      const tile = grid.tileMap.get(createTileKey(occupant.position.x, occupant.position.y));
+      if (!tile) {
+        continue;
+      }
+      entries.set(occupant.id, { occupant, tile });
+    }
+    return entries;
+  }, [grid, occupants]);
+
+  useEffect(() => {
+    const sprites = occupantSpritesRef.current;
+    const now = performance.now();
+    const localId = localOccupantId ?? null;
+
+    for (const id of Array.from(sprites.keys())) {
+      if (!occupantTargets.has(id)) {
+        sprites.delete(id);
+      }
+    }
+
+    for (const [id, entry] of occupantTargets.entries()) {
+      const { occupant, tile } = entry;
+      const baseX = tile.centerX;
+      const baseY = tile.screenY + tile.height - FOOT_OFFSET;
+      const avatarIndex = getAvatarVariantIndex(occupant);
+      const existing = sprites.get(id);
+
+      if (!existing) {
+        sprites.set(id, {
+          id,
+          username: occupant.username,
+          gridX: tile.gridX,
+          gridY: tile.gridY,
+          tileWidth: tile.width,
+          baseX,
+          baseY,
+          currentX: baseX,
+          currentY: baseY,
+          startX: baseX,
+          startY: baseY,
+          targetX: baseX,
+          targetY: baseY,
+          startTime: now,
+          duration: 0,
+          avatarIndex,
+          isLocal: occupant.id === localId,
+        });
+        continue;
+      }
+
+      existing.username = occupant.username;
+      existing.gridX = tile.gridX;
+      existing.gridY = tile.gridY;
+      existing.tileWidth = tile.width;
+      existing.baseX = baseX;
+      existing.baseY = baseY;
+      existing.isLocal = occupant.id === localId;
+      existing.avatarIndex = avatarIndex;
+
+      if (existing.targetX !== baseX || existing.targetY !== baseY) {
+        existing.startX = existing.currentX;
+        existing.startY = existing.currentY;
+        existing.startTime = now;
+        existing.targetX = baseX;
+        existing.targetY = baseY;
+        existing.duration = MOVEMENT_DURATION_MS;
+      } else if (existing.duration <= 0) {
+        existing.currentX = baseX;
+        existing.currentY = baseY;
+      }
+    }
+  }, [occupantTargets, localOccupantId]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -235,31 +462,62 @@ const GridCanvas = ({
       return;
     }
 
-    const context = prepareContext(canvas);
-    if (!context) {
-      return;
-    }
+    let disposed = false;
 
-    renderGrid(
-      context,
-      grid,
-      hoveredTile,
-      lockedTileKeys,
-      noPickupTileKeys,
-      pendingTileKey,
-      occupantSprites,
-      localOccupantId,
-    );
-    context.restore();
-  }, [
-    grid,
-    hoveredTile,
-    lockedTileKeys,
-    noPickupTileKeys,
-    pendingTileKey,
-    occupantSprites,
-    localOccupantId,
-  ]);
+    const renderFrame = (timestamp: number): void => {
+      if (disposed) {
+        return;
+      }
+
+      const context = prepareContext(canvas);
+      if (!context) {
+        animationFrameRef.current = requestAnimationFrame(renderFrame);
+        return;
+      }
+
+      try {
+        updateSpritePositions(occupantSpritesRef.current, timestamp);
+
+        drawBackground(context, assetsRef.current);
+
+        for (const tile of grid.tiles) {
+          drawTile(context, tile, {
+            hovered: hoveredTileRef.current?.key === tile.key,
+            locked: lockedTilesRef.current.has(tile.key),
+            pending: pendingTileKeyRef.current === tile.key,
+            noPickup:
+              !lockedTilesRef.current.has(tile.key) &&
+              noPickupTilesRef.current.has(tile.key),
+          });
+        }
+
+        const orderedSprites = Array.from(occupantSpritesRef.current.values()).sort((a, b) => {
+          if (a.gridY === b.gridY) {
+            return a.gridX - b.gridX;
+          }
+          return a.gridY - b.gridY;
+        });
+
+        for (const sprite of orderedSprites) {
+          drawOccupant(context, sprite, assetsRef.current);
+        }
+      } finally {
+        context.restore();
+      }
+
+      animationFrameRef.current = requestAnimationFrame(renderFrame);
+    };
+
+    animationFrameRef.current = requestAnimationFrame(renderFrame);
+
+    return () => {
+      disposed = true;
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+    };
+  }, [grid]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -274,20 +532,21 @@ const GridCanvas = ({
       const x = (event.clientX - rect.left) * scaleX;
       const y = (event.clientY - rect.top) * scaleY;
 
-      setPointer({ x, y });
-
       const tile = findTileAtPoint(grid, x, y);
       setHoveredTile((previous) => {
         if (previous?.key === tile?.key) {
           return previous;
         }
-
         return tile;
       });
+      hoveredTileRef.current = tile;
+
+      setPointer({ x, y });
     };
 
     const handlePointerLeave = (): void => {
       setHoveredTile(null);
+      hoveredTileRef.current = null;
       setPointer(null);
     };
 


### PR DESCRIPTION
## Summary
- draw the development room background and placeholder avatar PNGs with eased interpolation and a local highlight inside the grid canvas
- maintain client-side sprite animation state tied to authoritative move acks while preloading sprite assets on boot
- document the new canvas behavior, screenshot, and next focus areas in README.md and AGENT.md

## Testing
- pnpm --filter @bitby/schemas build
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d431c058a08333a0864db0cccaf066