### PR TITLE
Handle occupant departures in realtime flow

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -494,14 +494,14 @@ When implementing, **Codex should**:
 
 ---
 
-## 24) Progress Snapshot — 2025-09-26
+## 24) Progress Snapshot — 2025-09-24
 
 - ✅ Client grid renderer + chrome are live with the spec-mandated blocking reconnect overlay driven by a reusable `useRealtimeConnection` hook.
-- ✅ Fastify Socket.IO endpoint now validates HS256 JWTs issued from `/auth/login`, returns a development room snapshot inside `auth:ok`, closes idle sockets after the 30 s heartbeat window, and accepts `move` envelopes with `move:ok` / `move:err` replies plus `room:occupant_moved` broadcasts.
-- ✅ Shared schema package now covers the core envelope plus development room/move payloads so the client and server validate optimistic movement and room snapshots against the same definitions.
+- ✅ Fastify Socket.IO endpoint now validates HS256 JWTs issued from `/auth/login`, returns a development room snapshot inside `auth:ok`, closes idle sockets after the 30 s heartbeat window, accepts `move` envelopes with `move:ok` / `move:err` replies, and emits `room:occupant_moved` plus `room:occupant_left` broadcasts so every instance converges on the same presence list when sockets disconnect.
+- ✅ Shared schema package now covers the core envelope plus development room/move payloads, including the `room:occupant_left` definition used by both tiers to prune avatars after disconnects.
 - ✅ Client dev workflow automatically rebuilds `@bitby/schemas` before Vite starts (with a dedicated `pnpm --filter @bitby/schemas dev` watcher) so the workspace no longer crashes on fresh clones when resolving shared envelopes.
-- ✅ React client performs the `/auth/login` flow automatically, surfaces heartbeat-driven reconnect status, draws the development room background, foot-anchors placeholder avatar PNGs with snug underfoot username labels, and keeps optimistic moves visually aligned via eased interpolation while authoritative acks reconcile state. Admin quick toggles now hide the grid entirely, enable a barely-there hidden-grid hover outline, and switch move animations on or off while movement clicks refuse tiles that are locked or already occupied.
-- ✅ Strict Mode lifecycle handling in `useRealtimeConnection` now resets its disposal guard and treats intentional `AbortController` cancellations as benign, so `/auth/login` no longer aborts under automation. Latest overlay-free screenshot: `browser:/invocations/hsmymagx/artifacts/artifacts/bitby-connected.png`.
+- ✅ React client performs the `/auth/login` flow automatically, surfaces heartbeat-driven reconnect status, draws the development room background, foot-anchors placeholder avatar PNGs with snug underfoot username labels, keeps optimistic moves visually aligned via eased interpolation while authoritative acks reconcile state, and now consumes `room:occupant_left` packets to drop stale occupants immediately. Admin quick toggles still hide the grid entirely, enable a barely-there hidden-grid hover outline, and switch move animations on or off while movement clicks refuse tiles that are locked or already occupied.
+- ✅ Strict Mode lifecycle handling in `useRealtimeConnection` now resets its disposal guard and treats intentional `AbortController` cancellations as benign, so `/auth/login` no longer aborts under automation. Latest overlay-free screenshot: `browser:/invocations/nlvmljto/artifacts/artifacts/bitby-connected.png`.
 
 ### Immediate Next Focus
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -483,14 +483,12 @@ When implementing, **Codex should**:
 
 ## 23) Ready‑to‑Implement Tasks (First Sprint)
 
-1) Client grid renderer with top‑right anchor & diamond hit test; draw cell centers for dev overlay.
-2) Socket.IO client with heartbeat + blocking reconnect overlay.
-3) Socket.IO server endpoints: `auth`, `move`, `chat`; Redis room pub/sub skeleton.
-4) Postgres schema & migrations; seed users/room.
-5) Basic right panel and bottom dock (slide-left, tab).
-6) Item click → panel info; pickup rule gating.
-7) Metrics & health endpoints.
-8) JSON Schemas for `auth`, `move`, `chat`; OpenAPI for `/auth` REST.
+1) Socket.IO client with heartbeat + blocking reconnect overlay.
+2) Socket.IO server endpoints: `auth`, `move`, `chat`; Redis room pub/sub skeleton.
+3) Postgres schema & migrations; seed users/room.
+4) Item click → panel info; pickup rule gating.
+5) Metrics & health endpoints.
+6) JSON Schemas for `auth`, `move`, `chat`; OpenAPI for `/auth` REST.
 
 ---
 

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -271,9 +271,22 @@ body {
   margin-bottom: 8px;
 }
 
+.right-panel__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .right-panel h1 {
   margin: 0;
   font-size: 21px;
+}
+
+.right-panel__subtitle {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(234, 242, 255, 0.76);
 }
 
 .right-panel__header-divider {
@@ -301,6 +314,10 @@ body {
   padding-right: 2px;
 }
 
+.right-panel__sections--item {
+  padding-right: 4px;
+}
+
 .right-panel__section {
   display: flex;
   flex-direction: column;
@@ -318,6 +335,133 @@ body {
 .right-panel__section p {
   margin: 0;
   line-height: 1.65;
+}
+
+.item-info {
+  background: rgba(17, 27, 40, 0.82);
+  border: 1px solid rgba(122, 209, 255, 0.18);
+  border-radius: 12px;
+  padding: 18px 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+}
+
+.item-info__header h2 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: #f5fbff;
+}
+
+.item-info__header p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(234, 242, 255, 0.82);
+}
+
+.item-info__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 20px;
+}
+
+.item-info__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-info__meta dt {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(122, 209, 255, 0.7);
+}
+
+.item-info__meta dd {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.item-info__coordinate {
+  font-variant-numeric: tabular-nums;
+}
+
+.item-info__status {
+  font-weight: 600;
+}
+
+.item-info__status--ready {
+  color: #67f6a0;
+}
+
+.item-info__status--blocked {
+  color: #ff6b7a;
+}
+
+.item-info__status--pending {
+  color: #ffd166;
+}
+
+.item-info__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.item-info__actions button {
+  flex: 0 0 auto;
+  min-width: 0;
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: none;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.item-info__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.item-info__actions button:not(:disabled) {
+  background: linear-gradient(135deg, #7ad1ff, #4f9fff);
+  color: #0c1522;
+  box-shadow: 0 10px 20px rgba(122, 209, 255, 0.28);
+}
+
+.item-info__actions button:not(:disabled):hover,
+.item-info__actions button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(122, 209, 255, 0.35);
+}
+
+.item-info__actions button:focus-visible {
+  outline: 2px solid rgba(122, 209, 255, 0.9);
+  outline-offset: 3px;
+}
+
+.item-info__secondary {
+  background: transparent !important;
+  color: rgba(234, 242, 255, 0.82) !important;
+  border: 1px solid rgba(122, 209, 255, 0.25) !important;
+  box-shadow: none !important;
+}
+
+.item-info__secondary:not(:disabled):hover,
+.item-info__secondary:not(:disabled):focus-visible {
+  background: rgba(122, 209, 255, 0.16) !important;
+}
+
+.item-info__hint {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: rgba(234, 242, 255, 0.7);
 }
 
 .primary-menu {
@@ -513,6 +657,70 @@ body {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+}
+
+.chat-drawer__composer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.chat-drawer__composer-label {
+  display: none;
+}
+
+.chat-drawer__composer input {
+  flex: 1 1 auto;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 209, 255, 0.28);
+  background: rgba(12, 18, 28, 0.65);
+  color: #eaf2ff;
+  font-size: 13px;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.chat-drawer__composer input::placeholder {
+  color: rgba(234, 242, 255, 0.45);
+}
+
+.chat-drawer__composer input:focus-visible {
+  outline: 2px solid #7ad1ff;
+  outline-offset: 2px;
+  border-color: rgba(122, 209, 255, 0.65);
+  background: rgba(21, 32, 48, 0.8);
+}
+
+.chat-drawer__composer input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chat-drawer__composer-send {
+  flex: 0 0 auto;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #7ad1ff, #5e9fff);
+  color: #0c121c;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: filter 160ms ease, transform 160ms ease;
+}
+
+.chat-drawer__composer-send:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(0.2);
+}
+
+.chat-drawer__composer-send:not(:disabled):hover,
+.chat-drawer__composer-send:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.08);
+  outline: none;
 }
 
 .chat-log__messages {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "openapi-types": "^12.1.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,3 +1,6 @@
 export * from './ws/envelope.js';
 export * from './ws/move.js';
 export * from './ws/room.js';
+export * from './ws/auth.js';
+export * from './ws/chat.js';
+export * from './openapi/auth.js';

--- a/packages/schemas/src/openapi/auth.ts
+++ b/packages/schemas/src/openapi/auth.ts
@@ -1,0 +1,100 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+export const authLoginOpenApiDocument: OpenAPIV3_1.Document = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Bitby Auth API',
+    version: '0.1.0',
+    description: 'Authentication endpoints for the Bitby development environment.',
+  },
+  paths: {
+    '/auth/login': {
+      post: {
+        summary: 'Authenticate a user and issue a JWT',
+        operationId: 'login',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['username', 'password'],
+                properties: {
+                  username: { type: 'string', minLength: 1, maxLength: 64 },
+                  password: { type: 'string', minLength: 1, maxLength: 256 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Login succeeded',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['token', 'expiresIn', 'user'],
+                  properties: {
+                    token: { type: 'string' },
+                    expiresIn: { type: 'integer', minimum: 60 },
+                    user: {
+                      type: 'object',
+                      additionalProperties: false,
+                      required: ['id', 'username', 'roles'],
+                      properties: {
+                        id: { type: 'string' },
+                        username: { type: 'string' },
+                        roles: {
+                          type: 'array',
+                          items: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Invalid request payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['message'],
+                  properties: {
+                    message: { type: 'string' },
+                    issues: {
+                      type: 'array',
+                      items: { type: 'object' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Authentication failed',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['message'],
+                  properties: {
+                    message: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {},
+};

--- a/packages/schemas/src/ws/auth.ts
+++ b/packages/schemas/src/ws/auth.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const authRequestDataSchema = z.object({
+  token: z.string().min(1, 'token is required'),
+});
+
+export const authRequestJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['token'],
+  properties: {
+    token: {
+      type: 'string',
+      minLength: 1,
+    },
+  },
+} as const;
+
+export type AuthRequestData = z.infer<typeof authRequestDataSchema>;

--- a/packages/schemas/src/ws/chat.ts
+++ b/packages/schemas/src/ws/chat.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { buildEnvelopeSchema } from './envelope.js';
+
+export const chatSendRequestDataSchema = z.object({
+  body: z.string().min(1, 'body is required').max(500, 'body must be 500 characters or fewer'),
+  idempotencyKey: z.string().min(1).max(64).optional(),
+});
+
+export const chatSendRequestEnvelopeSchema = buildEnvelopeSchema(chatSendRequestDataSchema);
+
+export const chatMessageBroadcastSchema = z.object({
+  id: z.string().min(1, 'message id required'),
+  userId: z.string().min(1, 'userId required'),
+  username: z.string().min(1, 'username required'),
+  roles: z.array(z.string()).default([]),
+  body: z.string().min(1),
+  createdAt: z.string().min(1),
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+});
+
+export const chatMessageBroadcastEnvelopeSchema = buildEnvelopeSchema(
+  chatMessageBroadcastSchema,
+);
+
+export const chatSendRequestJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['body'],
+  properties: {
+    body: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 500,
+    },
+    idempotencyKey: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 64,
+    },
+  },
+} as const;
+
+export const chatMessageBroadcastJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'userId', 'username', 'roles', 'body', 'createdAt', 'roomSeq'],
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    userId: { type: 'string', minLength: 1 },
+    username: { type: 'string', minLength: 1 },
+    roles: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    body: { type: 'string', minLength: 1 },
+    createdAt: { type: 'string', minLength: 1, format: 'date-time' },
+    roomSeq: { type: 'integer', minimum: 0 },
+  },
+} as const;
+
+export type ChatSendRequest = z.infer<typeof chatSendRequestDataSchema>;
+export type ChatMessageBroadcast = z.infer<typeof chatMessageBroadcastSchema>;

--- a/packages/schemas/src/ws/move.ts
+++ b/packages/schemas/src/ws/move.ts
@@ -10,6 +10,17 @@ export const moveRequestDataSchema = z.object({
 
 export const moveRequestEnvelopeSchema = buildEnvelopeSchema(moveRequestDataSchema);
 
+export const moveRequestJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['x', 'y'],
+  properties: {
+    x: { type: 'integer', minimum: 0 },
+    y: { type: 'integer', minimum: 0 },
+  },
+} as const;
+
 const roomSeqSchema = z.number().int().min(0, 'roomSeq must be non-negative');
 
 export const moveOkDataSchema = z.object({
@@ -20,10 +31,23 @@ export const moveOkDataSchema = z.object({
 
 export const moveOkEnvelopeSchema = buildEnvelopeSchema(moveOkDataSchema);
 
+export const moveOkJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['x', 'y', 'roomSeq'],
+  properties: {
+    x: { type: 'integer', minimum: 0 },
+    y: { type: 'integer', minimum: 0 },
+    roomSeq: { type: 'integer', minimum: 0 },
+  },
+} as const;
+
 export const moveErrorCodeSchema = z.enum([
   'invalid_tile',
   'locked_tile',
   'not_in_room',
+  'occupied',
 ]);
 
 export const moveErrorDataSchema = z.object({
@@ -41,5 +65,38 @@ export const moveErrorDataSchema = z.object({
 });
 
 export const moveErrorEnvelopeSchema = buildEnvelopeSchema(moveErrorDataSchema);
+
+export const moveErrorJsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  type: 'object',
+  additionalProperties: false,
+  required: ['code', 'at', 'current', 'roomSeq'],
+  properties: {
+    code: {
+      type: 'string',
+      enum: ['invalid_tile', 'locked_tile', 'not_in_room', 'occupied'],
+    },
+    message: { type: 'string' },
+    at: {
+      type: 'object',
+      required: ['x', 'y'],
+      additionalProperties: false,
+      properties: {
+        x: { type: 'integer', minimum: 0 },
+        y: { type: 'integer', minimum: 0 },
+      },
+    },
+    current: {
+      type: 'object',
+      required: ['x', 'y'],
+      additionalProperties: false,
+      properties: {
+        x: { type: 'integer', minimum: 0 },
+        y: { type: 'integer', minimum: 0 },
+      },
+    },
+    roomSeq: { type: 'integer', minimum: 0 },
+  },
+} as const;
 
 export type MoveErrorCode = z.infer<typeof moveErrorCodeSchema>;

--- a/packages/schemas/src/ws/room.ts
+++ b/packages/schemas/src/ws/room.ts
@@ -30,7 +30,19 @@ export const roomOccupantMovedDataSchema = z.object({
   roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
 });
 
+export const roomOccupantLeftDataSchema = z.object({
+  occupantId: z.string().min(1, 'occupant id required'),
+  lastPosition: z
+    .object({
+      x: z.number().int().min(0, 'position.x must be non-negative'),
+      y: z.number().int().min(0, 'position.y must be non-negative'),
+    })
+    .optional(),
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+});
+
 export type RoomTileFlag = z.infer<typeof roomTileFlagSchema>;
 export type RoomOccupant = z.infer<typeof roomOccupantSchema>;
 export type RoomSnapshot = z.infer<typeof roomSnapshotSchema>;
 export type RoomOccupantMovedData = z.infer<typeof roomOccupantMovedDataSchema>;
+export type RoomOccupantLeftData = z.infer<typeof roomOccupantLeftDataSchema>;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,14 +18,18 @@
     "argon2": "^0.44.0",
     "dotenv": "^16.4.5",
     "fastify": "^4.26.2",
+    "ioredis": "^5.8.0",
     "jsonwebtoken": "^9.0.2",
+    "pg": "^8.16.3",
     "pino-pretty": "^11.0.0",
+    "prom-client": "^15.1.3",
     "socket.io": "^4.8.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.12.7",
+    "@types/pg": "^8.6.6",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
     "tslib": "^2.6.2",

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -38,7 +38,21 @@ const configSchema = z.object({
   TOKEN_TTL_SECONDS: z
     .preprocess((value) => numericEnv(value, 3600), z.number().int().min(60))
     .default(3600),
-  CLIENT_ORIGIN: z.string().default("http://localhost:5173")
+  CLIENT_ORIGIN: z.string().default("http://localhost:5173"),
+  PGHOST: z.string().default("127.0.0.1"),
+  PGPORT: z
+    .preprocess((value) => numericEnv(value, 5432), z.number().int().min(1).max(65535))
+    .default(5432),
+  PGDATABASE: z.string().default("bitby"),
+  PGUSER: z.string().default("bitby"),
+  PGPASSWORD: z.string().default("bitby"),
+  PG_POOL_MIN: z
+    .preprocess((value) => numericEnv(value, 0), z.number().int().min(0))
+    .default(0),
+  PG_POOL_MAX: z
+    .preprocess((value) => numericEnv(value, 10), z.number().int().min(1))
+    .default(10),
+  REDIS_URL: z.string().default("redis://127.0.0.1:6379"),
 });
 
 export type ServerConfig = z.infer<typeof configSchema>;
@@ -87,7 +101,15 @@ export const loadConfig = (env: NodeJS.ProcessEnv = process.env): ServerConfig =
     JWT_ISSUER: env.JWT_ISSUER,
     JWT_AUDIENCE: env.JWT_AUDIENCE,
     TOKEN_TTL_SECONDS: env.TOKEN_TTL_SECONDS,
-    CLIENT_ORIGIN: env.CLIENT_ORIGIN
+    CLIENT_ORIGIN: env.CLIENT_ORIGIN,
+    PGHOST: env.PGHOST,
+    PGPORT: env.PGPORT,
+    PGDATABASE: env.PGDATABASE,
+    PGUSER: env.PGUSER,
+    PGPASSWORD: env.PGPASSWORD,
+    PG_POOL_MIN: env.PG_POOL_MIN,
+    PG_POOL_MAX: env.PG_POOL_MAX,
+    REDIS_URL: env.REDIS_URL,
   });
 
   return parsed;

--- a/packages/server/src/db/chat.ts
+++ b/packages/server/src/db/chat.ts
@@ -1,0 +1,112 @@
+import type { Pool } from 'pg';
+
+export interface ChatMessageRecord {
+  id: string;
+  roomId: string;
+  userId: string;
+  username: string;
+  roles: string[];
+  body: string;
+  createdAt: Date;
+  roomSeq: number;
+}
+
+export interface ChatStore {
+  createMessage(
+    input: {
+      id: string;
+      roomId: string;
+      userId: string;
+      body: string;
+      roomSeq: number;
+    },
+  ): Promise<ChatMessageRecord>;
+  listRecentMessages(roomId: string, limit: number): Promise<ChatMessageRecord[]>;
+}
+
+const mapRow = (row: {
+  id: string;
+  room_id: string;
+  user_id: string;
+  username: string;
+  roles: string[] | null;
+  body: string;
+  created_at: Date;
+  room_seq: string | number;
+}): ChatMessageRecord => ({
+  id: row.id,
+  roomId: row.room_id,
+  userId: row.user_id,
+  username: row.username,
+  roles: Array.isArray(row.roles) ? row.roles : [],
+  body: row.body,
+  createdAt: new Date(row.created_at),
+  roomSeq: typeof row.room_seq === 'number' ? row.room_seq : Number.parseInt(row.room_seq, 10),
+});
+
+export const createChatStore = (pool: Pool): ChatStore => {
+  const createMessage = async ({
+    id,
+    roomId,
+    userId,
+    body,
+    roomSeq,
+  }: {
+    id: string;
+    roomId: string;
+    userId: string;
+    body: string;
+    roomSeq: number;
+  }): Promise<ChatMessageRecord> => {
+    const result = await pool.query<{
+      id: string;
+      room_id: string;
+      user_id: string;
+      body: string;
+      created_at: Date;
+      username: string;
+      roles: string[] | null;
+      room_seq: string | number;
+    }>(
+      `INSERT INTO chat_message (id, room_id, user_id, body, room_seq)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING id, room_id, user_id, body, created_at, room_seq,
+                   (SELECT username FROM app_user WHERE id = chat_message.user_id) AS username,
+                   (SELECT roles FROM app_user WHERE id = chat_message.user_id) AS roles`,
+      [id, roomId, userId, body, roomSeq],
+    );
+
+    return mapRow(result.rows[0]);
+  };
+
+  const listRecentMessages = async (
+    roomId: string,
+    limit: number,
+  ): Promise<ChatMessageRecord[]> => {
+    const result = await pool.query<{
+      id: string;
+      room_id: string;
+      user_id: string;
+      body: string;
+      created_at: Date;
+      username: string;
+      roles: string[] | null;
+      room_seq: string | number;
+    }>(
+      `SELECT cm.id, cm.room_id, cm.user_id, cm.body, cm.created_at, cm.room_seq, au.username, au.roles
+         FROM chat_message cm
+         JOIN app_user au ON au.id = cm.user_id
+        WHERE cm.room_id = $1
+        ORDER BY cm.room_seq DESC, cm.id DESC
+        LIMIT $2`,
+      [roomId, limit],
+    );
+
+    return result.rows.map((row) => mapRow(row)).reverse();
+  };
+
+  return {
+    createMessage,
+    listRecentMessages,
+  };
+};

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -1,0 +1,181 @@
+import type { Pool, PoolClient } from 'pg';
+
+interface Migration {
+  id: string;
+  statements: string[];
+}
+
+const MIGRATION_TABLE = 'schema_migration';
+const DEV_ROOM_ID = '11111111-1111-1111-1111-111111111111';
+const USER_PASSWORD_HASH =
+  '$argon2id$v=19$m=65536,t=3,p=4$F65uLJH6eRV81ypU4z3HRg$ZcuxQnFZWAVuEV+kW2TTN5JMcZIMkvYm6kgOOy2L6cg';
+
+const USERS = [
+  {
+    id: '11111111-1111-1111-1111-111111111201',
+    username: 'test',
+    rolesSql: "ARRAY['user']",
+  },
+  {
+    id: '11111111-1111-1111-1111-111111111202',
+    username: 'test2',
+    rolesSql: "ARRAY['user']",
+  },
+  {
+    id: '11111111-1111-1111-1111-111111111203',
+    username: 'test3',
+    rolesSql: "ARRAY['user']",
+  },
+  {
+    id: '11111111-1111-1111-1111-111111111204',
+    username: 'test4',
+    rolesSql: "ARRAY['user']",
+  },
+  {
+    id: '11111111-1111-1111-1111-111111111299',
+    username: 'npc-guide',
+    rolesSql: "ARRAY['npc']",
+  },
+] as const;
+
+const INITIAL_TILE_FLAGS = [
+  { x: 2, y: 8, locked: false, noPickup: true },
+  { x: 7, y: 3, locked: true, noPickup: false },
+];
+
+const MIGRATIONS: Migration[] = [
+  {
+    id: '0001_initial',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS app_user (
+        id uuid PRIMARY KEY,
+        username text UNIQUE NOT NULL,
+        password_hash text NOT NULL,
+        roles text[] NOT NULL DEFAULT ARRAY[]::text[],
+        created_at timestamptz DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS room (
+        id uuid PRIMARY KEY,
+        slug text UNIQUE NOT NULL,
+        name text NOT NULL,
+        room_seq bigint NOT NULL DEFAULT 1,
+        created_at timestamptz DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS room_tile_flag (
+        room_id uuid NOT NULL REFERENCES room(id) ON DELETE CASCADE,
+        x integer NOT NULL,
+        y integer NOT NULL,
+        locked boolean NOT NULL DEFAULT false,
+        no_pickup boolean NOT NULL DEFAULT false,
+        PRIMARY KEY (room_id, x, y)
+      )`,
+      `CREATE TABLE IF NOT EXISTS room_avatar (
+        user_id uuid PRIMARY KEY REFERENCES app_user(id) ON DELETE CASCADE,
+        room_id uuid REFERENCES room(id) ON DELETE SET NULL,
+        x integer NOT NULL,
+        y integer NOT NULL,
+        updated_at timestamptz DEFAULT now()
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_room_avatar_room ON room_avatar(room_id)`,
+      `CREATE TABLE IF NOT EXISTS chat_message (
+        id uuid PRIMARY KEY,
+        room_id uuid NOT NULL REFERENCES room(id) ON DELETE CASCADE,
+        user_id uuid NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+        body text NOT NULL,
+        created_at timestamptz DEFAULT now(),
+        room_seq bigint NOT NULL DEFAULT 1
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_chat_message_room_ts ON chat_message(room_id, created_at, id)`
+    ],
+  },
+  {
+    id: '0002_seed_dev_room',
+    statements: [
+      `INSERT INTO room (id, slug, name, room_seq)
+        VALUES ('${DEV_ROOM_ID}', 'dev-room', 'Development Plaza', 1)
+        ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+      ...USERS.map(
+        (user) =>
+          `INSERT INTO app_user (id, username, password_hash, roles)
+            VALUES ('${user.id}', '${user.username}', '${USER_PASSWORD_HASH}', ${user.rolesSql})
+            ON CONFLICT (username) DO UPDATE SET password_hash = EXCLUDED.password_hash, roles = EXCLUDED.roles`,
+      ),
+      ...INITIAL_TILE_FLAGS.map(
+        (flag) =>
+          `INSERT INTO room_tile_flag (room_id, x, y, locked, no_pickup)
+            VALUES ('${DEV_ROOM_ID}', ${flag.x}, ${flag.y}, ${flag.locked}, ${flag.noPickup})
+            ON CONFLICT (room_id, x, y) DO UPDATE SET locked = EXCLUDED.locked, no_pickup = EXCLUDED.no_pickup`,
+      ),
+      `INSERT INTO room_avatar (user_id, room_id, x, y)
+         VALUES ('11111111-1111-1111-1111-111111111299', '${DEV_ROOM_ID}', 6, 4)
+         ON CONFLICT (user_id) DO UPDATE SET room_id = EXCLUDED.room_id, x = EXCLUDED.x, y = EXCLUDED.y`,
+    ],
+  },
+  {
+    id: '0003_chat_sequence',
+    statements: [
+      `ALTER TABLE chat_message ADD COLUMN IF NOT EXISTS room_seq bigint NOT NULL DEFAULT 1`,
+      `CREATE INDEX IF NOT EXISTS idx_chat_message_room_seq ON chat_message(room_id, room_seq)`
+    ],
+  },
+];
+
+const ensureMigrationTable = async (pool: Pool): Promise<void> => {
+  await pool.query(
+    `CREATE TABLE IF NOT EXISTS ${MIGRATION_TABLE} (
+      id text PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )`,
+  );
+};
+
+const hasMigrationRun = async (client: PoolClient, id: string): Promise<boolean> => {
+  const result = await client.query<{ id: string }>(
+    `SELECT id FROM ${MIGRATION_TABLE} WHERE id = $1 LIMIT 1`,
+    [id],
+  );
+  return (result.rowCount ?? 0) > 0;
+};
+
+const recordMigration = async (client: PoolClient, id: string): Promise<void> => {
+  await client.query(
+    `INSERT INTO ${MIGRATION_TABLE} (id) VALUES ($1) ON CONFLICT (id) DO NOTHING`,
+    [id],
+  );
+};
+
+export const runMigrations = async (pool: Pool): Promise<void> => {
+  await ensureMigrationTable(pool);
+
+  for (const migration of MIGRATIONS) {
+    const client = await pool.connect();
+    let inTransaction = false;
+    try {
+      const applied = await hasMigrationRun(client, migration.id);
+      if (applied) {
+        continue;
+      }
+
+      await client.query('BEGIN');
+      inTransaction = true;
+      for (const statement of migration.statements) {
+        await client.query(statement);
+      }
+      await recordMigration(client, migration.id);
+      await client.query('COMMIT');
+      inTransaction = false;
+    } catch (error) {
+      if (inTransaction) {
+        try {
+          await client.query('ROLLBACK');
+        } catch (rollbackError) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to rollback migration', rollbackError);
+        }
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+};

--- a/packages/server/src/db/pool.ts
+++ b/packages/server/src/db/pool.ts
@@ -1,0 +1,17 @@
+import { Pool } from 'pg';
+import type { ServerConfig } from '../config.js';
+
+export const createPgPool = (config: ServerConfig): Pool =>
+  new Pool({
+    host: config.PGHOST,
+    port: config.PGPORT,
+    database: config.PGDATABASE,
+    user: config.PGUSER,
+    password: config.PGPASSWORD,
+    min: config.PG_POOL_MIN,
+    max: config.PG_POOL_MAX,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+  });
+
+export type DatabasePool = ReturnType<typeof createPgPool>;

--- a/packages/server/src/db/rooms.ts
+++ b/packages/server/src/db/rooms.ts
@@ -1,0 +1,201 @@
+import type { Pool } from 'pg';
+import type { RoomSnapshotOccupant } from '../auth/types.js';
+
+export interface RoomRecord {
+  id: string;
+  slug: string;
+  name: string;
+  roomSeq: number;
+}
+
+export interface TileFlagRecord {
+  x: number;
+  y: number;
+  locked: boolean;
+  noPickup: boolean;
+}
+
+export type RoomOccupantRecord = RoomSnapshotOccupant & { roomId: string | null };
+
+export interface RoomStore {
+  getRoomBySlug(slug: string): Promise<RoomRecord | null>;
+  getRoomById(id: string): Promise<RoomRecord | null>;
+  getTileFlags(roomId: string): Promise<TileFlagRecord[]>;
+  listOccupants(roomId: string): Promise<RoomSnapshotOccupant[]>;
+  getOccupant(userId: string): Promise<RoomOccupantRecord | null>;
+  upsertOccupantPosition(
+    userId: string,
+    roomId: string,
+    position: { x: number; y: number },
+  ): Promise<RoomSnapshotOccupant>;
+  clearOccupant(userId: string): Promise<void>;
+  incrementRoomSequence(roomId: string): Promise<number>;
+}
+
+const mapRoomRow = (row: {
+  id: string;
+  slug: string;
+  name: string;
+  room_seq: string | number;
+}): RoomRecord => ({
+  id: row.id,
+  slug: row.slug,
+  name: row.name,
+  roomSeq: typeof row.room_seq === 'number' ? row.room_seq : Number.parseInt(row.room_seq, 10),
+});
+
+const mapOccupantRow = (row: {
+  id: string;
+  username: string;
+  roles: string[] | null;
+  x: number;
+  y: number;
+  room_id?: string | null;
+}): RoomSnapshotOccupant & { roomId: string | null } => ({
+  id: row.id,
+  username: row.username,
+  roles: Array.isArray(row.roles) ? row.roles : [],
+  position: { x: row.x, y: row.y },
+  roomId: row.room_id ?? null,
+});
+
+export const createRoomStore = (pool: Pool): RoomStore => {
+  const getRoomBySlug = async (slug: string): Promise<RoomRecord | null> => {
+    const result = await pool.query<{ id: string; slug: string; name: string; room_seq: number }>(
+      `SELECT id, slug, name, room_seq FROM room WHERE slug = $1 LIMIT 1`,
+      [slug],
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapRoomRow(result.rows[0]);
+  };
+
+  const getRoomById = async (id: string): Promise<RoomRecord | null> => {
+    const result = await pool.query<{ id: string; slug: string; name: string; room_seq: number }>(
+      `SELECT id, slug, name, room_seq FROM room WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapRoomRow(result.rows[0]);
+  };
+
+  const getTileFlags = async (roomId: string): Promise<TileFlagRecord[]> => {
+    const result = await pool.query<{ x: number; y: number; locked: boolean; no_pickup: boolean }>(
+      `SELECT x, y, locked, no_pickup FROM room_tile_flag WHERE room_id = $1`,
+      [roomId],
+    );
+
+    return result.rows.map((row) => ({
+      x: row.x,
+      y: row.y,
+      locked: row.locked,
+      noPickup: row.no_pickup,
+    }));
+  };
+
+  const listOccupants = async (roomId: string): Promise<RoomSnapshotOccupant[]> => {
+    const result = await pool.query<{
+      id: string;
+      username: string;
+      roles: string[] | null;
+      x: number;
+      y: number;
+    }>(
+      `SELECT au.id, au.username, au.roles, ra.x, ra.y
+         FROM room_avatar ra
+         JOIN app_user au ON au.id = ra.user_id
+        WHERE ra.room_id = $1
+        ORDER BY ra.y ASC, ra.x ASC`,
+      [roomId],
+    );
+
+    return result.rows.map((row) => {
+      const { roomId: _roomId, ...rest } = mapOccupantRow(row);
+      void _roomId;
+      return rest;
+    });
+  };
+
+  const getOccupant = async (userId: string): Promise<RoomOccupantRecord | null> => {
+    const result = await pool.query<{
+      id: string;
+      username: string;
+      roles: string[] | null;
+      x: number;
+      y: number;
+      room_id: string | null;
+    }>(
+      `SELECT au.id, au.username, au.roles, ra.x, ra.y, ra.room_id
+         FROM room_avatar ra
+         JOIN app_user au ON au.id = ra.user_id
+        WHERE ra.user_id = $1
+        LIMIT 1`,
+      [userId],
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    return mapOccupantRow(result.rows[0]);
+  };
+
+  const upsertOccupantPosition = async (
+    userId: string,
+    roomId: string,
+    position: { x: number; y: number },
+  ): Promise<RoomSnapshotOccupant> => {
+    await pool.query(
+      `INSERT INTO room_avatar (user_id, room_id, x, y)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (user_id)
+         DO UPDATE SET room_id = EXCLUDED.room_id, x = EXCLUDED.x, y = EXCLUDED.y, updated_at = now()`,
+      [userId, roomId, position.x, position.y],
+    );
+
+    const occupant = await getOccupant(userId);
+    if (!occupant) {
+      throw new Error(`Occupant ${userId} missing after upsert`);
+    }
+
+    const { roomId: _roomId, ...rest } = occupant;
+    void _roomId;
+    return rest;
+  };
+
+  const clearOccupant = async (userId: string): Promise<void> => {
+    await pool.query(`UPDATE room_avatar SET room_id = NULL WHERE user_id = $1`, [userId]);
+  };
+
+  const incrementRoomSequence = async (roomId: string): Promise<number> => {
+    const result = await pool.query<{ room_seq: string | number }>(
+      `UPDATE room SET room_seq = room_seq + 1 WHERE id = $1 RETURNING room_seq`,
+      [roomId],
+    );
+
+    if (result.rowCount === 0) {
+      throw new Error(`Room ${roomId} not found when incrementing sequence`);
+    }
+
+    const value = result.rows[0].room_seq;
+    return typeof value === 'number' ? value : Number.parseInt(value, 10);
+  };
+
+  return {
+    getRoomBySlug,
+    getRoomById,
+    getTileFlags,
+    listOccupants,
+    getOccupant,
+    upsertOccupantPosition,
+    clearOccupant,
+    incrementRoomSequence,
+  };
+};

--- a/packages/server/src/metrics/registry.ts
+++ b/packages/server/src/metrics/registry.ts
@@ -1,0 +1,38 @@
+import { collectDefaultMetrics, Counter, Gauge, Registry } from 'prom-client';
+
+export interface MetricsBundle {
+  registry: Registry;
+  activeConnections: Gauge;
+  moveEvents: Counter;
+  chatEvents: Counter;
+}
+
+export const createMetricsBundle = (): MetricsBundle => {
+  const registry = new Registry();
+  collectDefaultMetrics({ register: registry });
+
+  const activeConnections = new Gauge({
+    name: 'bitby_realtime_connections',
+    help: 'Number of active realtime websocket connections',
+    registers: [registry],
+  });
+
+  const moveEvents = new Counter({
+    name: 'bitby_move_events_total',
+    help: 'Count of processed move events',
+    registers: [registry],
+  });
+
+  const chatEvents = new Counter({
+    name: 'bitby_chat_events_total',
+    help: 'Count of processed chat messages',
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    activeConnections,
+    moveEvents,
+    chatEvents,
+  };
+};

--- a/packages/server/src/redis/pubsub.ts
+++ b/packages/server/src/redis/pubsub.ts
@@ -1,0 +1,121 @@
+import { Redis } from 'ioredis';
+import type { FastifyBaseLogger } from 'fastify';
+import type { ServerConfig } from '../config.js';
+
+const ROOM_CHAT_CHANNEL = (roomId: string): string => `room.${roomId}.chat`;
+
+export interface RoomChatEvent {
+  type: 'chat:new';
+  roomId: string;
+  payload: {
+    id: string;
+    userId: string;
+    username: string;
+    roles: string[];
+    body: string;
+    createdAt: string;
+    roomSeq: number;
+  };
+}
+
+export interface RoomPubSub {
+  publishChat(event: RoomChatEvent): Promise<void>;
+  subscribeToChat(roomId: string, handler: (event: RoomChatEvent) => void): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface PubSubMessage {
+  origin: string;
+  event: RoomChatEvent;
+}
+
+export const createRoomPubSub = async ({
+  config,
+  logger,
+  instanceId,
+}: {
+  config: ServerConfig;
+  logger: FastifyBaseLogger;
+  instanceId: string;
+}): Promise<RoomPubSub> => {
+  const publisher = new Redis(config.REDIS_URL, { lazyConnect: true });
+  const subscriber = new Redis(config.REDIS_URL, { lazyConnect: true });
+  const messageListeners = new Map<string, (channel: string, payload: string) => void>();
+  const channelHandlers = new Map<string, Set<(event: RoomChatEvent) => void>>();
+
+  publisher.on('error', (error: unknown) => {
+    logger.error({ err: error }, 'Redis publisher error');
+  });
+  subscriber.on('error', (error: unknown) => {
+    logger.error({ err: error }, 'Redis subscriber error');
+  });
+
+  await publisher.connect();
+  await subscriber.connect();
+
+  const publishChat = async (event: RoomChatEvent): Promise<void> => {
+    const payload: PubSubMessage = { origin: instanceId, event };
+    await publisher.publish(ROOM_CHAT_CHANNEL(event.roomId), JSON.stringify(payload));
+  };
+
+  const subscribeToChat = async (
+    roomId: string,
+    handler: (event: RoomChatEvent) => void,
+  ): Promise<void> => {
+    const channel = ROOM_CHAT_CHANNEL(roomId);
+    let handlers = channelHandlers.get(channel);
+    if (!handlers) {
+      handlers = new Set();
+      channelHandlers.set(channel, handlers);
+
+      const listener = (incomingChannel: string, payload: string) => {
+        if (incomingChannel !== channel) {
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(payload) as PubSubMessage;
+          if (!parsed || typeof parsed !== 'object') {
+            return;
+          }
+
+          if (parsed.origin === instanceId) {
+            return;
+          }
+
+          const currentHandlers = channelHandlers.get(channel);
+          if (!currentHandlers || currentHandlers.size === 0) {
+            return;
+          }
+
+          for (const fn of currentHandlers) {
+            fn(parsed.event);
+          }
+        } catch (error) {
+          logger.error({ err: error }, 'Failed to parse chat pubsub payload');
+        }
+      };
+
+      messageListeners.set(channel, listener);
+      subscriber.on('message', listener);
+    }
+
+    handlers.add(handler);
+    await subscriber.subscribe(channel);
+  };
+
+  const close = async (): Promise<void> => {
+    for (const listener of messageListeners.values()) {
+      subscriber.off('message', listener);
+    }
+    messageListeners.clear();
+    channelHandlers.clear();
+    await Promise.all([publisher.quit(), subscriber.quit()]);
+  };
+
+  return {
+    publishChat,
+    subscribeToChat,
+    close,
+  };
+};

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,11 +1,19 @@
+import { randomUUID } from 'node:crypto';
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
 import { Server as SocketIOServer } from 'socket.io';
 import type { ReadinessController } from './readiness.js';
 import type { ServerConfig } from './config.js';
-import { handleRealtimeConnection } from './ws/connection.js';
 import { authRoutes } from './api/auth.js';
 import { resolveCorsOrigins } from './config.js';
+import { createPgPool } from './db/pool.js';
+import { runMigrations } from './db/migrations.js';
+import { createUserStore } from './auth/store.js';
+import { createRoomStore } from './db/rooms.js';
+import { createChatStore } from './db/chat.js';
+import { createRoomPubSub } from './redis/pubsub.js';
+import { createMetricsBundle } from './metrics/registry.js';
+import { createRealtimeServer } from './ws/connection.js';
 
 const MAX_WS_MESSAGE_BYTES = 64 * 1024;
 
@@ -16,23 +24,44 @@ export interface CreateServerOptions {
 
 export const createServer = async ({
   config,
-  readiness
+  readiness,
 }: CreateServerOptions): Promise<FastifyInstance> => {
   const app = Fastify({
     logger: {
       level: config.LOG_LEVEL,
-      transport: config.NODE_ENV === 'development' ? { target: 'pino-pretty' } : undefined
-    }
+      transport: config.NODE_ENV === 'development' ? { target: 'pino-pretty' } : undefined,
+    },
+  });
+
+  const pool = createPgPool(config);
+  await runMigrations(pool);
+
+  const userStore = createUserStore(pool);
+  const roomStore = createRoomStore(pool);
+  const chatStore = createChatStore(pool);
+  const metrics = createMetricsBundle();
+  const instanceId = randomUUID();
+  const pubsub = await createRoomPubSub({
+    config,
+    logger: app.log.child({ scope: 'redis', instanceId }),
+    instanceId,
+  });
+  const realtime = await createRealtimeServer({
+    config,
+    roomStore,
+    chatStore,
+    pubsub,
+    metrics,
   });
 
   app.decorate('readiness', readiness);
   const corsOrigins = resolveCorsOrigins(config.CLIENT_ORIGIN);
   await app.register(cors, {
     origin: corsOrigins,
-    credentials: true
+    credentials: true,
   });
 
-  await app.register(authRoutes, { config });
+  await app.register(authRoutes, { config, userStore });
 
   app.get('/healthz', async () => ({ status: 'ok' }));
 
@@ -46,22 +75,26 @@ export const createServer = async ({
     return { status: 'ready' };
   });
 
+  app.get('/metrics', async (request, reply) => {
+    reply.header('Content-Type', metrics.registry.contentType);
+    return reply.send(await metrics.registry.metrics());
+  });
+
   const io = new SocketIOServer(app.server, {
     path: '/ws',
     maxHttpBufferSize: MAX_WS_MESSAGE_BYTES,
     transports: ['websocket'],
     cors: {
       origin: corsOrigins,
-      credentials: true
-    }
+      credentials: true,
+    },
   });
 
   io.on('connection', (socket) => {
-    handleRealtimeConnection({
+    realtime.handleConnection({
       app,
       socket,
       requestId: socket.id,
-      config
     });
   });
 
@@ -69,6 +102,9 @@ export const createServer = async ({
     await new Promise<void>((resolve) => {
       io.close(() => resolve());
     });
+    await realtime.shutdown();
+    await pubsub.close();
+    await pool.end();
   });
 
   return app;

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -1,24 +1,26 @@
+import { randomUUID } from 'node:crypto';
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify';
 import type { Socket } from 'socket.io';
 import {
+  chatSendRequestDataSchema,
   messageEnvelopeSchema,
   moveRequestDataSchema,
+  type ChatMessageBroadcast,
   type MessageEnvelope,
   type MoveErrorCode,
 } from '@bitby/schemas';
 import { z } from 'zod';
 import type { ServerConfig } from '../config.js';
 import { decodeToken } from '../auth/jwt.js';
-import type {
-  AuthenticatedUser,
-  RoomSnapshot,
-  RoomSnapshotOccupant,
-} from '../auth/types.js';
+import type { AuthenticatedUser, RoomSnapshot } from '../auth/types.js';
+import type { RoomStore, TileFlagRecord } from '../db/rooms.js';
+import type { ChatStore } from '../db/chat.js';
+import type { RoomPubSub, RoomChatEvent } from '../redis/pubsub.js';
+import type { MetricsBundle } from '../metrics/registry.js';
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const HEARTBEAT_GRACE_MS = HEARTBEAT_INTERVAL_MS * 2;
-const DEVELOPMENT_ROOM_ID = 'dev-room';
-const DEVELOPMENT_ROOM_NAME = 'Development Plaza';
+const DEVELOPMENT_ROOM_SLUG = 'dev-room';
 
 const GRID_ROW_COUNT = 10;
 const EVEN_ROW_COLUMNS = 10;
@@ -34,12 +36,7 @@ const DEVELOPMENT_SPAWN_POINTS: Array<{ x: number; y: number }> = [
   { x: 6, y: 3 },
 ];
 
-interface TileFlag {
-  x: number;
-  y: number;
-  locked: boolean;
-  noPickup: boolean;
-}
+interface TileFlag extends TileFlagRecord {}
 
 interface RegisteredConnection {
   socket: Socket;
@@ -47,12 +44,45 @@ interface RegisteredConnection {
   userId: string;
 }
 
+interface DevelopmentRoomState {
+  id: string;
+  name: string;
+  roomSeq: number;
+  tiles: TileFlag[];
+  tileIndex: Map<string, TileFlag>;
+  occupants: Map<string, RoomOccupant>;
+  connections: Map<string, RegisteredConnection>;
+}
+
+interface RoomOccupant {
+  id: string;
+  username: string;
+  roles: string[];
+  position: { x: number; y: number };
+}
+
 interface ConnectionContext {
   app: FastifyInstance;
   socket: Socket;
   requestId: string;
-  config: ServerConfig;
 }
+
+interface RealtimeDependencies {
+  config: ServerConfig;
+  roomStore: RoomStore;
+  chatStore: ChatStore;
+  pubsub: RoomPubSub;
+  metrics: MetricsBundle;
+}
+
+interface RealtimeServer {
+  handleConnection(context: ConnectionContext): void;
+  shutdown(): Promise<void>;
+}
+
+type EnvelopeData = Record<string, unknown>;
+
+type Envelope = MessageEnvelope<EnvelopeData>;
 
 type AuthOkPayload = EnvelopeData & {
   user: AuthenticatedUser;
@@ -62,119 +92,36 @@ type AuthOkPayload = EnvelopeData & {
   };
   heartbeatIntervalMs: number;
   roomSnapshot: RoomSnapshot;
+  chatHistory: ChatMessageBroadcast[];
 };
 
 const authPayloadSchema = z.object({
   token: z.string().min(1, 'token is required'),
 });
 
-type EnvelopeData = Record<string, unknown>;
-
-type Envelope = MessageEnvelope<EnvelopeData>;
-
 const createTileKey = (x: number, y: number): string => `${x},${y}`;
-
-const initialTileFlags: TileFlag[] = [
-  { x: 2, y: 8, locked: false, noPickup: true },
-  { x: 7, y: 3, locked: true, noPickup: false },
-];
-
-const developmentRoomState: {
-  id: string;
-  name: string;
-  roomSeq: number;
-  tiles: TileFlag[];
-  tileIndex: Map<string, TileFlag>;
-  occupants: Map<string, RoomSnapshotOccupant>;
-  connections: Map<string, RegisteredConnection>;
-} = {
-  id: DEVELOPMENT_ROOM_ID,
-  name: DEVELOPMENT_ROOM_NAME,
-  roomSeq: 1,
-  tiles: initialTileFlags,
-  tileIndex: new Map(initialTileFlags.map((tile) => [createTileKey(tile.x, tile.y), tile])),
-  occupants: new Map<string, RoomSnapshotOccupant>([
-    [
-      'npc-guide',
-      {
-        id: 'npc-guide',
-        username: 'Guide Bot',
-        roles: ['npc'],
-        position: { x: 6, y: 4 },
-      },
-    ],
-  ]),
-  connections: new Map(),
-};
 
 const getColumnsForRow = (row: number): number =>
   row % 2 === 0 ? EVEN_ROW_COLUMNS : ODD_ROW_COLUMNS;
 
-const isTileInBounds = (x: number, y: number): boolean => {
-  if (y < 0 || y >= GRID_ROW_COUNT || x < 0) {
-    return false;
-  }
+const toUnixTimestamp = () => Math.floor(Date.now() / 1000);
 
-  const columns = getColumnsForRow(y);
-  return x < columns;
-};
+const createEnvelope = (op: string, seq: number, data: EnvelopeData = {}): Envelope => ({
+  op,
+  seq,
+  ts: toUnixTimestamp(),
+  data,
+});
 
-const isTileLocked = (x: number, y: number): boolean =>
-  developmentRoomState.tileIndex.get(createTileKey(x, y))?.locked ?? false;
-
-const isTileOccupied = (x: number, y: number): boolean => {
-  for (const occupant of developmentRoomState.occupants.values()) {
-    if (occupant.position.x === x && occupant.position.y === y) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
-const findAvailableSpawn = (): { x: number; y: number } => {
-  for (const candidate of DEVELOPMENT_SPAWN_POINTS) {
-    if (isTileLocked(candidate.x, candidate.y)) {
-      continue;
-    }
-
-    if (!isTileOccupied(candidate.x, candidate.y)) {
-      return { ...candidate };
-    }
-  }
-
-  return { x: 5, y: 4 };
-};
-
-const cloneOccupant = (occupant: RoomSnapshotOccupant): RoomSnapshotOccupant => ({
+const cloneOccupant = (occupant: RoomOccupant): RoomOccupant => ({
   id: occupant.id,
   username: occupant.username,
   roles: [...occupant.roles],
   position: { x: occupant.position.x, y: occupant.position.y },
 });
 
-const ensureOccupantForUser = (user: AuthenticatedUser): RoomSnapshotOccupant => {
-  const existing = developmentRoomState.occupants.get(user.id);
-  if (existing) {
-    existing.username = user.username;
-    existing.roles = [...user.roles];
-    return existing;
-  }
-
-  const spawn = findAvailableSpawn();
-  const occupant: RoomSnapshotOccupant = {
-    id: user.id,
-    username: user.username,
-    roles: [...user.roles],
-    position: { x: spawn.x, y: spawn.y },
-  };
-
-  developmentRoomState.occupants.set(user.id, occupant);
-  return occupant;
-};
-
-const buildDevelopmentRoomSnapshot = (): RoomSnapshot => {
-  const occupants = Array.from(developmentRoomState.occupants.values())
+const sortOccupants = (map: Map<string, RoomOccupant>): RoomOccupant[] =>
+  Array.from(map.values())
     .map((occupant) => cloneOccupant(occupant))
     .sort((a, b) => {
       if (a.position.y === b.position.y) {
@@ -183,180 +130,6 @@ const buildDevelopmentRoomSnapshot = (): RoomSnapshot => {
 
       return a.position.y - b.position.y;
     });
-
-  return {
-    id: developmentRoomState.id,
-    name: developmentRoomState.name,
-    roomSeq: developmentRoomState.roomSeq,
-    occupants,
-    tiles: developmentRoomState.tiles.map((tile) => ({ ...tile })),
-  };
-};
-
-const registerRealtimeConnection = (
-  logger: FastifyBaseLogger,
-  socket: Socket,
-  user: AuthenticatedUser,
-): RoomSnapshot => {
-  ensureOccupantForUser(user);
-  developmentRoomState.connections.set(socket.id, { socket, logger, userId: user.id });
-  return buildDevelopmentRoomSnapshot();
-};
-
-const unregisterRealtimeConnection = (socket: Socket): void => {
-  const connection = developmentRoomState.connections.get(socket.id);
-  if (!connection) {
-    developmentRoomState.connections.delete(socket.id);
-    return;
-  }
-
-  developmentRoomState.connections.delete(socket.id);
-
-  const occupant = developmentRoomState.occupants.get(connection.userId);
-  if (!occupant) {
-    return;
-  }
-
-  developmentRoomState.occupants.delete(connection.userId);
-  developmentRoomState.roomSeq += 1;
-
-  broadcastOccupantLeft({
-    occupantId: occupant.id,
-    lastPosition: { ...occupant.position },
-    roomSeq: developmentRoomState.roomSeq,
-  });
-};
-
-const broadcastOccupantUpdate = (
-  occupant: RoomSnapshotOccupant,
-  roomSeq: number,
-  excludeSocketId?: string,
-): void => {
-  for (const connection of developmentRoomState.connections.values()) {
-    if (excludeSocketId && connection.socket.id === excludeSocketId) {
-      continue;
-    }
-
-    safeSend(
-      connection.logger,
-      connection.socket,
-      createEnvelope('room:occupant_moved', 0, {
-        occupant: cloneOccupant(occupant),
-        roomSeq,
-      }),
-    );
-  }
-};
-
-const broadcastOccupantLeft = ({
-  occupantId,
-  lastPosition,
-  roomSeq,
-}: {
-  occupantId: string;
-  lastPosition: { x: number; y: number };
-  roomSeq: number;
-}): void => {
-  for (const connection of developmentRoomState.connections.values()) {
-    safeSend(
-      connection.logger,
-      connection.socket,
-      createEnvelope('room:occupant_left', 0, {
-        occupantId,
-        lastPosition,
-        roomSeq,
-      }),
-    );
-  }
-};
-
-type MoveResult =
-  | {
-      ok: true;
-      occupant: RoomSnapshotOccupant;
-      roomSeq: number;
-      broadcast: boolean;
-    }
-  | {
-      ok: false;
-      code: MoveErrorCode;
-      message: string;
-      current: { x: number; y: number };
-      roomSeq: number;
-    };
-
-const attemptMove = (
-  userId: string,
-  target: { x: number; y: number },
-): MoveResult => {
-  const occupant = developmentRoomState.occupants.get(userId);
-  if (!occupant) {
-    return {
-      ok: false,
-      code: 'not_in_room',
-      message: 'User is not registered in the development room',
-      current: { x: 0, y: 0 },
-      roomSeq: developmentRoomState.roomSeq,
-    };
-  }
-
-  const currentPosition = { ...occupant.position };
-
-  if (!isTileInBounds(target.x, target.y)) {
-    return {
-      ok: false,
-      code: 'invalid_tile',
-      message: 'Target tile is outside the playable field',
-      current: currentPosition,
-      roomSeq: developmentRoomState.roomSeq,
-    };
-  }
-
-  if (isTileLocked(target.x, target.y)) {
-    return {
-      ok: false,
-      code: 'locked_tile',
-      message: 'Target tile is locked',
-      current: currentPosition,
-      roomSeq: developmentRoomState.roomSeq,
-    };
-  }
-
-  const alreadyAtTarget =
-    currentPosition.x === target.x && currentPosition.y === target.y;
-
-  if (alreadyAtTarget) {
-    return {
-      ok: true,
-      occupant: cloneOccupant(occupant),
-      roomSeq: developmentRoomState.roomSeq,
-      broadcast: false,
-    };
-  }
-
-  occupant.position = { x: target.x, y: target.y };
-  developmentRoomState.roomSeq += 1;
-
-  return {
-    ok: true,
-    occupant: cloneOccupant(occupant),
-    roomSeq: developmentRoomState.roomSeq,
-    broadcast: true,
-  };
-};
-
-const toUnixTimestamp = () => Math.floor(Date.now() / 1000);
-
-const createEnvelope = (
-  op: string,
-  seq: number,
-  data: EnvelopeData = {},
-): Envelope => ({
-  op,
-  seq,
-  ts: toUnixTimestamp(),
-  data,
-});
 
 const safeSend = (
   logger: FastifyBaseLogger,
@@ -389,231 +162,600 @@ const emitSystemMessage = (
   safeSend(logger, socket, createEnvelope(op, 0, data));
 };
 
-const handleAuth = (
-  logger: FastifyBaseLogger,
-  socket: Socket,
-  envelope: Envelope,
-  config: ServerConfig,
-  closeWithReason: (reason: string) => void,
-): AuthenticatedUser | null => {
-  const parsed = authPayloadSchema.safeParse(envelope.data);
-  if (!parsed.success) {
-    acknowledge(logger, socket, envelope, 'error:auth_invalid', {
-      message: 'Invalid auth payload',
-      issues: parsed.error.issues,
-    });
-    return null;
+export const createRealtimeServer = async ({
+  config,
+  roomStore,
+  chatStore,
+  pubsub,
+  metrics,
+}: RealtimeDependencies): Promise<RealtimeServer> => {
+  const roomRecord = await roomStore.getRoomBySlug(DEVELOPMENT_ROOM_SLUG);
+  if (!roomRecord) {
+    throw new Error('Development room is missing from the database');
   }
 
-  let authenticatedUser: AuthenticatedUser;
-  try {
-    authenticatedUser = decodeToken(parsed.data.token, config);
-  } catch (error) {
-    logger.warn({ err: error }, 'Rejected realtime auth token');
-    acknowledge(logger, socket, envelope, 'error:auth_invalid', {
-      message: 'Authentication failed: invalid token',
-    });
-    closeWithReason('Invalid auth token');
-    return null;
-  }
+  const tileFlags = await roomStore.getTileFlags(roomRecord.id);
+  const occupantList = await roomStore.listOccupants(roomRecord.id);
 
-  const snapshot = registerRealtimeConnection(logger, socket, authenticatedUser);
-  const payload: AuthOkPayload = {
-    user: authenticatedUser,
-    room: {
-      id: snapshot.id,
-      name: snapshot.name,
-    },
-    heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-    roomSnapshot: snapshot,
+  const developmentRoomState: DevelopmentRoomState = {
+    id: roomRecord.id,
+    name: roomRecord.name,
+    roomSeq: roomRecord.roomSeq,
+    tiles: tileFlags,
+    tileIndex: new Map(tileFlags.map((flag) => [createTileKey(flag.x, flag.y), flag])),
+    occupants: new Map(),
+    connections: new Map(),
   };
 
-  acknowledge(logger, socket, envelope, 'auth:ok', payload);
+  for (const occupant of occupantList) {
+    developmentRoomState.occupants.set(occupant.id, cloneOccupant(occupant));
+  }
 
-  emitSystemMessage(logger, socket, 'system:room_snapshot', {
-    message:
-      'Authoritative snapshot streaming is stubbed; using development fixtures.',
-    roomSeq: snapshot.roomSeq,
-    occupants: snapshot.occupants,
+  const updateRoomSeq = (roomSeq: number): void => {
+    if (roomSeq > developmentRoomState.roomSeq) {
+      developmentRoomState.roomSeq = roomSeq;
+    }
+  };
+
+  const buildSnapshot = (): RoomSnapshot => ({
+    id: developmentRoomState.id,
+    name: developmentRoomState.name,
+    roomSeq: developmentRoomState.roomSeq,
+    occupants: sortOccupants(developmentRoomState.occupants),
+    tiles: developmentRoomState.tiles.map((tile) => ({
+      x: tile.x,
+      y: tile.y,
+      locked: tile.locked,
+      noPickup: tile.noPickup,
+    })),
   });
 
-  const occupantForUser = snapshot.occupants.find(
-    (occupant) => occupant.id === authenticatedUser.id,
-  );
+  const isTileLocked = (x: number, y: number): boolean =>
+    developmentRoomState.tileIndex.get(createTileKey(x, y))?.locked ?? false;
 
-  if (occupantForUser) {
-    broadcastOccupantUpdate(occupantForUser, snapshot.roomSeq, socket.id);
-  }
-
-  return authenticatedUser;
-};
-
-export const handleRealtimeConnection = ({
-  app,
-  socket,
-  requestId,
-  config,
-}: ConnectionContext): void => {
-  const logger = app.log.child({ scope: 'ws', requestId });
-  let isAuthenticated = false;
-  let sessionUser: AuthenticatedUser | null = null;
-  let lastHeartbeatAt = Date.now();
-
-  const closeWithReason = (reason: string): void => {
-    try {
-      logger.warn({ reason }, 'Disconnecting realtime socket');
-      if (socket.connected) {
-        socket.disconnect(true);
-      }
-    } catch (error) {
-      logger.error({ err: error }, 'Failed to close websocket connection gracefully');
+  const isTileInBounds = (x: number, y: number): boolean => {
+    if (y < 0 || y >= GRID_ROW_COUNT || x < 0) {
+      return false;
     }
+
+    const columns = getColumnsForRow(y);
+    return x < columns;
   };
 
-  const heartbeatMonitor = setInterval(() => {
-    const elapsed = Date.now() - lastHeartbeatAt;
-    if (elapsed > HEARTBEAT_GRACE_MS) {
-      logger.warn({ elapsed }, 'Heartbeat window elapsed; closing connection');
-      closeWithReason('Heartbeat timeout');
-    }
-  }, HEARTBEAT_INTERVAL_MS);
+  const isTileOccupied = (x: number, y: number, excludeUserId?: string): boolean => {
+    for (const occupant of developmentRoomState.occupants.values()) {
+      if (occupant.id === excludeUserId) {
+        continue;
+      }
 
-  socket.on('message', (raw: unknown) => {
-    let candidate: unknown = raw;
-
-    if (typeof raw === 'string') {
-      try {
-        candidate = JSON.parse(raw);
-      } catch (error) {
-        logger.warn({ err: error }, 'Received invalid JSON payload');
-        safeSend(
-          logger,
-          socket,
-          createEnvelope('error:invalid_json', 0, {
-            message: 'Messages must be valid JSON',
-          }),
-        );
-        closeWithReason('Invalid JSON payload');
-        return;
+      if (occupant.position.x === x && occupant.position.y === y) {
+        return true;
       }
     }
 
-    const envelopeResult = messageEnvelopeSchema.safeParse(candidate);
-    if (!envelopeResult.success) {
-      logger.warn({ issues: envelopeResult.error.issues }, 'Received malformed envelope');
-      safeSend(logger, socket, createEnvelope('error:envelope', 0, {
-        message: 'Malformed envelope',
-        issues: envelopeResult.error.issues,
-      }));
+    return false;
+  };
+
+  const findAvailableSpawn = (): { x: number; y: number } => {
+    for (const candidate of DEVELOPMENT_SPAWN_POINTS) {
+      if (isTileLocked(candidate.x, candidate.y)) {
+        continue;
+      }
+
+      if (!isTileOccupied(candidate.x, candidate.y)) {
+        return { ...candidate };
+      }
+    }
+
+    return { x: 5, y: 4 };
+  };
+
+  const ensureOccupant = async (
+    user: AuthenticatedUser,
+  ): Promise<{ occupant: RoomOccupant; wasNew: boolean }> => {
+    const existing = developmentRoomState.occupants.get(user.id);
+    if (existing) {
+      existing.username = user.username;
+      existing.roles = [...user.roles];
+      return { occupant: existing, wasNew: false };
+    }
+
+    const fromStore = await roomStore.getOccupant(user.id);
+    if (fromStore && fromStore.roomId === developmentRoomState.id) {
+      const occupant: RoomOccupant = {
+        id: fromStore.id,
+        username: user.username,
+        roles: [...user.roles],
+        position: { ...fromStore.position },
+      };
+      developmentRoomState.occupants.set(user.id, occupant);
+      return { occupant, wasNew: false };
+    }
+
+    const spawn = findAvailableSpawn();
+    const created = await roomStore.upsertOccupantPosition(user.id, developmentRoomState.id, spawn);
+    const occupant: RoomOccupant = {
+      id: created.id,
+      username: user.username,
+      roles: [...user.roles],
+      position: { ...created.position },
+    };
+    developmentRoomState.occupants.set(user.id, occupant);
+
+    const newRoomSeq = await roomStore.incrementRoomSequence(developmentRoomState.id);
+    updateRoomSeq(newRoomSeq);
+
+    return { occupant, wasNew: true };
+  };
+
+  const registerConnection = async (
+    logger: FastifyBaseLogger,
+    socket: Socket,
+    user: AuthenticatedUser,
+  ): Promise<{ snapshot: RoomSnapshot; occupant: RoomOccupant }> => {
+    const { occupant } = await ensureOccupant(user);
+    developmentRoomState.connections.set(socket.id, { socket, logger, userId: user.id });
+
+    return {
+      snapshot: buildSnapshot(),
+      occupant,
+    };
+  };
+
+  const unregisterConnection = async (socket: Socket): Promise<void> => {
+    const connection = developmentRoomState.connections.get(socket.id);
+    if (!connection) {
       return;
     }
 
-    const envelope = envelopeResult.data;
-    lastHeartbeatAt = Date.now();
+    developmentRoomState.connections.delete(socket.id);
 
-    switch (envelope.op) {
-      case 'ping': {
-        acknowledge(logger, socket, envelope, 'pong', {
-          serverTs: toUnixTimestamp(),
-        });
-        return;
-      }
-      case 'auth': {
-        if (isAuthenticated) {
-          acknowledge(logger, socket, envelope, 'error:auth_state', {
-            message: 'Auth already completed for this session',
-          });
-          return;
-        }
-
-        const user = handleAuth(logger, socket, envelope, config, closeWithReason);
-        if (user) {
-          isAuthenticated = true;
-          sessionUser = user;
-          lastHeartbeatAt = Date.now();
-          logger.info({ userId: user.id }, 'Client authenticated');
-        }
-        return;
-      }
-      case 'move': {
-        if (!isAuthenticated || !sessionUser) {
-          acknowledge(logger, socket, envelope, 'error:not_authenticated', {
-            message: 'Authenticate before issuing realtime operations',
-          });
-          return;
-        }
-
-        const payloadResult = moveRequestDataSchema.safeParse(envelope.data);
-        if (!payloadResult.success) {
-          acknowledge(logger, socket, envelope, 'error:move_payload', {
-            message: 'Invalid move payload',
-            issues: payloadResult.error.issues,
-          });
-          return;
-        }
-
-        const target = payloadResult.data;
-        const moveResult = attemptMove(sessionUser.id, target);
-
-        if (moveResult.ok) {
-          acknowledge(logger, socket, envelope, 'move:ok', {
-            x: moveResult.occupant.position.x,
-            y: moveResult.occupant.position.y,
-            roomSeq: moveResult.roomSeq,
-          });
-          if (moveResult.broadcast) {
-            broadcastOccupantUpdate(moveResult.occupant, moveResult.roomSeq);
-          }
-          logger.info(
-            {
-              userId: sessionUser.id,
-              x: moveResult.occupant.position.x,
-              y: moveResult.occupant.position.y,
-              roomSeq: moveResult.roomSeq,
-            },
-            'Processed move operation',
-          );
-        } else {
-          acknowledge(logger, socket, envelope, 'move:err', {
-            code: moveResult.code,
-            message: moveResult.message,
-            at: target,
-            current: moveResult.current,
-            roomSeq: moveResult.roomSeq,
-          });
-          logger.warn(
-            {
-              userId: sessionUser.id,
-              target,
-              code: moveResult.code,
-            },
-            'Rejected move operation',
-          );
-        }
-        return;
-      }
-      default: {
-        if (!isAuthenticated) {
-          acknowledge(logger, socket, envelope, 'error:not_authenticated', {
-            message: 'Authenticate before issuing realtime operations',
-          });
-          return;
-        }
-
-        acknowledge(logger, socket, envelope, 'error:unhandled_op', {
-          message: `Operation ${envelope.op} is not yet implemented`,
-        });
-      }
+    const occupant = developmentRoomState.occupants.get(connection.userId);
+    if (!occupant) {
+      return;
     }
+
+    developmentRoomState.occupants.delete(connection.userId);
+    await roomStore.clearOccupant(connection.userId);
+    const newRoomSeq = await roomStore.incrementRoomSequence(developmentRoomState.id);
+    updateRoomSeq(newRoomSeq);
+
+    for (const other of developmentRoomState.connections.values()) {
+      safeSend(
+        other.logger,
+        other.socket,
+        createEnvelope('room:occupant_left', 0, {
+          occupantId: occupant.id,
+          lastPosition: { ...occupant.position },
+          roomSeq: developmentRoomState.roomSeq,
+        }),
+      );
+    }
+  };
+
+  const broadcastOccupantMove = (
+    occupant: RoomOccupant,
+    roomSeq: number,
+    excludeSocketId?: string,
+  ): void => {
+    for (const connection of developmentRoomState.connections.values()) {
+      if (excludeSocketId && connection.socket.id === excludeSocketId) {
+        continue;
+      }
+
+      safeSend(
+        connection.logger,
+        connection.socket,
+        createEnvelope('room:occupant_moved', 0, {
+          occupant: cloneOccupant(occupant),
+          roomSeq,
+        }),
+      );
+    }
+  };
+
+  const broadcastChatEvent = (event: RoomChatEvent): void => {
+    updateRoomSeq(event.payload.roomSeq);
+    for (const connection of developmentRoomState.connections.values()) {
+      safeSend(
+        connection.logger,
+        connection.socket,
+        createEnvelope('chat:new', 0, event.payload),
+      );
+    }
+  };
+
+  await pubsub.subscribeToChat(developmentRoomState.id, (event) => {
+    metrics.chatEvents.inc();
+    broadcastChatEvent(event);
   });
+
+  const attemptMove = async (
+    userId: string,
+    target: { x: number; y: number },
+  ): Promise<
+    | {
+        ok: true;
+        occupant: RoomOccupant;
+        roomSeq: number;
+      }
+    | {
+        ok: false;
+        code: MoveErrorCode;
+        message: string;
+        current: { x: number; y: number };
+        roomSeq: number;
+      }
+  > => {
+    const occupant = developmentRoomState.occupants.get(userId);
+    if (!occupant) {
+      return {
+        ok: false,
+        code: 'not_in_room',
+        message: 'User is not registered in the room',
+        current: { x: 0, y: 0 },
+        roomSeq: developmentRoomState.roomSeq,
+      };
+    }
+
+    const currentPosition = { ...occupant.position };
+
+    if (!isTileInBounds(target.x, target.y)) {
+      return {
+        ok: false,
+        code: 'invalid_tile',
+        message: 'Target tile is outside the playable field',
+        current: currentPosition,
+        roomSeq: developmentRoomState.roomSeq,
+      };
+    }
+
+    if (isTileLocked(target.x, target.y)) {
+      return {
+        ok: false,
+        code: 'locked_tile',
+        message: 'Target tile is locked',
+        current: currentPosition,
+        roomSeq: developmentRoomState.roomSeq,
+      };
+    }
+
+    if (isTileOccupied(target.x, target.y, userId)) {
+      return {
+        ok: false,
+        code: 'occupied',
+        message: 'Target tile is currently occupied',
+        current: currentPosition,
+        roomSeq: developmentRoomState.roomSeq,
+      };
+    }
+
+    if (currentPosition.x === target.x && currentPosition.y === target.y) {
+      return {
+        ok: true,
+        occupant: cloneOccupant(occupant),
+        roomSeq: developmentRoomState.roomSeq,
+      };
+    }
+
+    occupant.position = { ...target };
+    await roomStore.upsertOccupantPosition(userId, developmentRoomState.id, target);
+    const newRoomSeq = await roomStore.incrementRoomSequence(developmentRoomState.id);
+    updateRoomSeq(newRoomSeq);
+
+    return {
+      ok: true,
+      occupant: cloneOccupant(occupant),
+      roomSeq: developmentRoomState.roomSeq,
+    };
+  };
+
+  const handleAuth = async (
+    logger: FastifyBaseLogger,
+    socket: Socket,
+    envelope: Envelope,
+    closeWithReason: (reason: string) => void,
+  ): Promise<AuthenticatedUser | null> => {
+    const parsed = authPayloadSchema.safeParse(envelope.data);
+    if (!parsed.success) {
+      acknowledge(logger, socket, envelope, 'error:auth_invalid', {
+        message: 'Invalid auth payload',
+        issues: parsed.error.issues,
+      });
+      return null;
+    }
+
+    let authenticatedUser: AuthenticatedUser;
+    try {
+      authenticatedUser = decodeToken(parsed.data.token, config);
+    } catch (error) {
+      logger.warn({ err: error }, 'Rejected realtime auth token');
+      acknowledge(logger, socket, envelope, 'error:auth_invalid', {
+        message: 'Authentication failed: invalid token',
+      });
+      closeWithReason('Invalid auth token');
+      return null;
+    }
+
+    const { snapshot } = await registerConnection(logger, socket, authenticatedUser);
+    const chatHistoryRecords = await chatStore.listRecentMessages(
+      developmentRoomState.id,
+      50,
+    );
+
+    const payload: AuthOkPayload = {
+      user: authenticatedUser,
+      room: {
+        id: snapshot.id,
+        name: snapshot.name,
+      },
+      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      roomSnapshot: snapshot,
+      chatHistory: chatHistoryRecords.map((record) => ({
+        id: record.id,
+        userId: record.userId,
+        username: record.username,
+        roles: record.roles,
+        body: record.body,
+        createdAt: record.createdAt.toISOString(),
+        roomSeq: record.roomSeq,
+      })),
+    };
+
+    acknowledge(logger, socket, envelope, 'auth:ok', payload);
+
+    const occupant = developmentRoomState.occupants.get(authenticatedUser.id);
+    if (occupant) {
+      broadcastOccupantMove(occupant, developmentRoomState.roomSeq, socket.id);
+    }
+
+    emitSystemMessage(logger, socket, 'system:room_snapshot', {
+      message: 'Authoritative snapshot streaming is stubbed; using development fixtures.',
+      roomSeq: snapshot.roomSeq,
+      occupants: snapshot.occupants,
+    });
+
+    return authenticatedUser;
+  };
+
+  const handleChatSend = async (
+    logger: FastifyBaseLogger,
+    socket: Socket,
+    envelope: Envelope,
+    user: AuthenticatedUser,
+  ): Promise<void> => {
+    const parsed = chatSendRequestDataSchema.safeParse(envelope.data);
+    if (!parsed.success) {
+      acknowledge(logger, socket, envelope, 'error:chat_payload', {
+        message: 'Invalid chat payload',
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+
+    const body = parsed.data.body.trim();
+    if (body.length === 0) {
+      acknowledge(logger, socket, envelope, 'error:chat_payload', {
+        message: 'Chat message body cannot be empty',
+      });
+      return;
+    }
+
+    const newRoomSeq = await roomStore.incrementRoomSequence(developmentRoomState.id);
+    updateRoomSeq(newRoomSeq);
+
+    const record = await chatStore.createMessage({
+      id: randomUUID(),
+      roomId: developmentRoomState.id,
+      userId: user.id,
+      body,
+      roomSeq: developmentRoomState.roomSeq,
+    });
+
+    const event: RoomChatEvent = {
+      type: 'chat:new',
+      roomId: developmentRoomState.id,
+      payload: {
+        id: record.id,
+        userId: record.userId,
+        username: record.username,
+        roles: record.roles,
+        body: record.body,
+        createdAt: record.createdAt.toISOString(),
+        roomSeq: record.roomSeq,
+      },
+    };
+
+    metrics.chatEvents.inc();
+    broadcastChatEvent(event);
+    await pubsub.publishChat(event);
+
+    acknowledge(logger, socket, envelope, 'chat:ok', {
+      messageId: record.id,
+    });
+  };
+
+  const handleConnection = ({ app, socket, requestId }: ConnectionContext): void => {
+    const logger = app.log.child({ scope: 'ws', requestId });
+    metrics.activeConnections.inc();
+
+    let isAuthenticated = false;
+    let sessionUser: AuthenticatedUser | null = null;
+    let lastHeartbeatAt = Date.now();
+
+    const closeWithReason = (reason: string): void => {
+      try {
+        logger.warn({ reason }, 'Disconnecting realtime socket');
+        if (socket.connected) {
+          socket.disconnect(true);
+        }
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to close websocket connection gracefully');
+      }
+    };
+
+    const heartbeatMonitor = setInterval(() => {
+      const elapsed = Date.now() - lastHeartbeatAt;
+      if (elapsed > HEARTBEAT_GRACE_MS) {
+        logger.warn({ elapsed }, 'Heartbeat window elapsed; closing connection');
+        closeWithReason('Heartbeat timeout');
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    socket.on('message', (raw: unknown) => {
+      void (async () => {
+        let candidate: unknown = raw;
+
+        if (typeof raw === 'string') {
+          try {
+            candidate = JSON.parse(raw);
+          } catch (error) {
+            logger.warn({ err: error }, 'Received invalid JSON payload');
+            safeSend(
+              logger,
+              socket,
+              createEnvelope('error:invalid_json', 0, {
+                message: 'Messages must be valid JSON',
+              }),
+            );
+            closeWithReason('Invalid JSON payload');
+            return;
+          }
+        }
+
+        const envelopeResult = messageEnvelopeSchema.safeParse(candidate);
+        if (!envelopeResult.success) {
+          logger.warn({ issues: envelopeResult.error.issues }, 'Received malformed envelope');
+          safeSend(
+            logger,
+            socket,
+            createEnvelope('error:envelope', 0, {
+              message: 'Malformed envelope',
+              issues: envelopeResult.error.issues,
+            }),
+          );
+          return;
+        }
+
+        const envelope = envelopeResult.data;
+        lastHeartbeatAt = Date.now();
+
+        switch (envelope.op) {
+          case 'ping': {
+            acknowledge(logger, socket, envelope, 'pong', {
+              serverTs: toUnixTimestamp(),
+            });
+            return;
+          }
+          case 'auth': {
+            if (isAuthenticated) {
+              acknowledge(logger, socket, envelope, 'error:auth_state', {
+                message: 'Auth already completed for this session',
+              });
+              return;
+            }
+
+            const user = await handleAuth(logger, socket, envelope, closeWithReason);
+            if (user) {
+              isAuthenticated = true;
+              sessionUser = user;
+              lastHeartbeatAt = Date.now();
+              logger.info({ userId: user.id }, 'Client authenticated');
+            }
+            return;
+          }
+          case 'move': {
+            if (!isAuthenticated || !sessionUser) {
+              acknowledge(logger, socket, envelope, 'error:not_authenticated', {
+                message: 'Authenticate before issuing realtime operations',
+              });
+              return;
+            }
+
+            const payloadResult = moveRequestDataSchema.safeParse(envelope.data);
+            if (!payloadResult.success) {
+              acknowledge(logger, socket, envelope, 'error:move_payload', {
+                message: 'Invalid move payload',
+                issues: payloadResult.error.issues,
+              });
+              return;
+            }
+
+            const target = payloadResult.data;
+            const moveResult = await attemptMove(sessionUser.id, target);
+
+            if (moveResult.ok) {
+              metrics.moveEvents.inc();
+              acknowledge(logger, socket, envelope, 'move:ok', {
+                x: moveResult.occupant.position.x,
+                y: moveResult.occupant.position.y,
+                roomSeq: moveResult.roomSeq,
+              });
+              broadcastOccupantMove(moveResult.occupant, moveResult.roomSeq, socket.id);
+              logger.info(
+                {
+                  userId: sessionUser.id,
+                  x: moveResult.occupant.position.x,
+                  y: moveResult.occupant.position.y,
+                  roomSeq: moveResult.roomSeq,
+                },
+                'Processed move operation',
+              );
+            } else {
+              acknowledge(logger, socket, envelope, 'move:err', {
+                code: moveResult.code,
+                message: moveResult.message,
+                at: target,
+                current: moveResult.current,
+                roomSeq: moveResult.roomSeq,
+              });
+              logger.warn(
+                {
+                  userId: sessionUser.id,
+                  target,
+                  code: moveResult.code,
+                },
+                'Rejected move operation',
+              );
+            }
+            return;
+          }
+          case 'chat:send': {
+            if (!isAuthenticated || !sessionUser) {
+              acknowledge(logger, socket, envelope, 'error:not_authenticated', {
+                message: 'Authenticate before issuing realtime operations',
+              });
+              return;
+            }
+
+            await handleChatSend(logger, socket, envelope, sessionUser);
+            return;
+          }
+          default: {
+            if (!isAuthenticated) {
+              acknowledge(logger, socket, envelope, 'error:not_authenticated', {
+                message: 'Authenticate before issuing realtime operations',
+              });
+              return;
+            }
+
+            acknowledge(logger, socket, envelope, 'error:unhandled_op', {
+              message: `Operation ${envelope.op} is not yet implemented`,
+            });
+          }
+        }
+      })().catch((error: unknown) => {
+        logger.error({ err: error }, 'Unhandled error while processing realtime message');
+      });
+    });
 
     socket.on('disconnect', (reason: string) => {
       clearInterval(heartbeatMonitor);
-      unregisterRealtimeConnection(socket);
-      logger.info(
-        { reason, userId: sessionUser?.id ?? null },
-        'Socket.IO connection closed',
-      );
+      metrics.activeConnections.dec();
+      void unregisterConnection(socket).catch((error) => {
+        logger.error({ err: error }, 'Failed to unregister realtime connection');
+      });
+      logger.info({ reason, userId: sessionUser?.id ?? null }, 'Socket.IO connection closed');
     });
 
     socket.on('error', (error: Error) => {
@@ -621,7 +763,24 @@ export const handleRealtimeConnection = ({
     });
 
     emitSystemMessage(logger, socket, 'system:hello', {
-    message: 'Authenticate via { op: "auth" } to start streaming realtime state.',
-    heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-  });
+      message: 'Authenticate via { op: "auth" } to start streaming realtime state.',
+      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+    });
+  };
+
+  const shutdown = async (): Promise<void> => {
+    for (const connection of developmentRoomState.connections.values()) {
+      try {
+        connection.socket.disconnect(true);
+      } catch (error) {
+        connection.logger.error({ err: error }, 'Error while closing realtime socket');
+      }
+    }
+    developmentRoomState.connections.clear();
+  };
+
+  return {
+    handleConnection,
+    shutdown,
+  };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
 
   packages/schemas:
     dependencies:
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -124,12 +127,21 @@ importers:
       fastify:
         specifier: ^4.26.2
         version: 4.29.1
+      ioredis:
+        specifier: ^5.8.0
+        version: 5.8.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
       pino-pretty:
         specifier: ^11.0.0
         version: 11.3.0
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1
@@ -143,6 +155,9 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.19.17
+      '@types/pg':
+        specifier: ^8.6.6
+        version: 8.15.5
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -956,6 +971,10 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
+  /@ioredis/commands@1.4.0:
+    resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
+    dev: false
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1013,6 +1032,11 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
     dev: true
+
+  /@opentelemetry/api@1.9.0:
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+    dev: false
 
   /@phc/format@1.0.0:
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
@@ -1299,6 +1323,14 @@ packages:
     resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
     dependencies:
       undici-types: 6.21.0
+
+  /@types/pg@8.15.5:
+    resolution: {integrity: sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==}
+    dependencies:
+      '@types/node': 20.19.17
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+    dev: true
 
   /@types/prop-types@15.7.15:
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1698,6 +1730,10 @@ packages:
       require-from-string: 2.0.2
     dev: true
 
+  /bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+    dev: false
+
   /brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
     dependencies:
@@ -1807,6 +1843,11 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: true
+
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1922,7 +1963,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1980,6 +2020,11 @@ packages:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
     dev: true
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -2711,6 +2756,23 @@ packages:
       side-channel: 1.1.0
     dev: true
 
+  /ioredis@5.8.0:
+    resolution: {integrity: sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.4.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3021,8 +3083,16 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+    dev: false
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
     dev: false
 
   /lodash.isboolean@3.0.3:
@@ -3257,6 +3327,10 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
+  /openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+    dev: false
+
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3339,6 +3413,65 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
+  /pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+    dev: false
+
+  /pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  /pg-pool@3.10.1(pg@8.16.3):
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+    dependencies:
+      pg: 8.16.3
+    dev: false
+
+  /pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  /pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  /pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+    dev: false
+
+  /pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    dependencies:
+      split2: 4.2.0
+    dev: false
+
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
@@ -3417,6 +3550,24 @@ packages:
       source-map-js: 1.2.1
     dev: true
 
+  /postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  /postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  /postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  /postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      xtend: 4.0.2
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3457,6 +3608,14 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
     dev: false
 
   /proxy-addr@2.0.7:
@@ -3529,6 +3688,18 @@ packages:
   /real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+    dev: false
+
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
     dev: false
 
   /regexp.prototype.flags@1.5.4:
@@ -3835,6 +4006,10 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
     dev: true
@@ -3885,6 +4060,12 @@ packages:
   /symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
+
+  /tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+    dependencies:
+      bintrees: 1.0.2
+    dev: false
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -4327,6 +4508,10 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
     dev: false
+
+  /xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}


### PR DESCRIPTION
## Summary
- remove disconnected occupants from the in-memory development room and broadcast `room:occupant_left` envelopes
- extend the shared schema and client realtime hook to validate and consume the new departure payloads so stale avatars disappear immediately
- document the new presence handling and updated connectivity screenshot in the handoff notes and agent guidance

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4460931c483338aa5d7f0bcbc0f85