### PR TITLE
Implement authoritative item pickup pipeline

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -483,11 +483,11 @@ When implementing, **Codex should**:
 
 ## 23) Ready‑to‑Implement Tasks (First Sprint)
 
-1) Wire the item pickup loop (server validation, inventory persistence, optimistic UI) so the panel’s “Saml Op” control reflects authoritative acknowledgements.
-2) Add realtime typing bubbles and chat bubble rendering on the canvas while persisting the chat drawer’s system-message preference per user.
-3) Build right-click context menus for tiles, items, and avatars with the gating rules outlined in the Master Spec (Info/Saml Op, player actions).
-4) Extend the admin quick menu so each toggle calls the authoritative API (lock/noPickup, latency trace) and persists dev overrides via Postgres/Redis.
-5) Establish automated integration/E2E tests that exercise auth → chat → move → item flows against the Postgres/Redis stack and wire them into CI.
+1) Add realtime typing bubbles and chat bubble rendering on the canvas while persisting the chat drawer’s system-message preference per user.
+2) Build right-click context menus for tiles, items, and avatars with the gating rules outlined in the Master Spec (Info/Saml Op, player actions).
+3) Extend the admin quick menu so each toggle calls the authoritative API (lock/noPickup, latency trace) and persists dev overrides via Postgres/Redis.
+4) Establish automated integration/E2E tests that exercise auth → chat → move → item flows against the Postgres/Redis stack and wire them into CI.
+5) Design the persistent inventory/backpack presentation (inspection + future drop/wear flows) now that pickups are persisted.
 6) Audit `[realtime]` debug logging before release (demote, gate, or remove) so production builds ship without noisy console output.
 
 ---
@@ -495,18 +495,24 @@ When implementing, **Codex should**:
 ## 24) Progress Snapshot — 2025-09-25
 
 - ✅ `useRealtimeConnection` authenticates via `/auth/login`, maintains heartbeats, hydrates the room snapshot, streams historical chat, appends live `chat:new` envelopes, and exposes a composer that emits `chat:send` while the blocking overlay clears automatically after reconnect.
-- ✅ The React client now renders seeded room items beneath avatars, tracks per-item hit boxes, routes selections into the right panel’s item info view, and honours the chat drawer’s system-message toggle alongside the existing admin quick toggles and movement gating.
-- ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat history to Postgres, relays cross-instance chat through Redis pub/sub, and exposes `/healthz`, `/readyz`, and `/metrics` endpoints instrumented with Prometheus counters.
-- ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, and `chat` plus an OpenAPI document for `/auth/login`, keeping both tiers on a single contract for realtime and REST payloads.
+- ✅ The React client now renders seeded room items beneath avatars, tracks per-item hit boxes, wires the right panel’s “Saml Op” button into the optimistic → authoritative pickup loop, and honours the chat drawer’s system-message toggle alongside the existing admin quick toggles and movement gating.
+- ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat`/`item:pickup` envelopes, persists chat history and inventory state to Postgres, relays room chat via Redis pub/sub, and exposes `/healthz`, `/readyz`, and `/metrics` endpoints instrumented with Prometheus counters.
+- ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, `chat`, and `item` envelopes plus an OpenAPI document for `/auth/login`, keeping both tiers on a single contract for realtime and REST payloads.
 - ✅ Workspace scripts rebuild shared schemas before Vite launches, and lint/typecheck/test/build workflows cover the new chat, item, and observability codepaths.
-- Latest connectivity screenshot with chat + item panel: `browser:/invocations/nkjxmmlj/artifacts/artifacts/bitby-connected.png`.
+- Latest connectivity screenshot with chat + item panel: `browser:/invocations/pcpnzfin/artifacts/artifacts/bitby-connected.png`.
+
+**Environment Notes**
+
+- When Docker is unavailable, install and start Postgres + Redis via the distro services (`sudo apt install postgresql redis-server`, `sudo service postgresql start`, `sudo service redis-server start`), then seed the `bitby` role/database as documented in the README.
+- Launch dev tiers with `pnpm --filter @bitby/server dev` and `pnpm --filter @bitby/client dev -- --host 0.0.0.0 --port 5173`; the realtime socket expects Postgres + Redis to be online before boot.
+
 
 ### Immediate Next Focus
 
-1. Wire the pickup pipeline end-to-end (server validation, inventory persistence, optimistic UI) so the right panel button reflects authoritative acknowledgements.
-2. Add typing bubbles and chat bubble rendering on the canvas while persisting the system-message preference.
-3. Implement the spec’d context menus for tiles/items/avatars and extend the admin quick menu to call authoritative toggles.
-4. Stand up integration/E2E tests that drive auth → chat → move → item flows against Postgres/Redis and gate CI on them.
+1. Add typing bubbles and chat bubble rendering on the canvas while persisting the system-message preference.
+2. Implement the spec’d context menus for tiles/items/avatars and extend the admin quick menu to call authoritative toggles.
+3. Stand up integration/E2E tests that drive auth → chat → move → item flows against Postgres/Redis and gate CI on them.
+4. Design and implement the inventory/backpack presentation now that pickups persist (inspection, future drop/wear flows).
 5. Gate or demote the `[realtime]` debug logging before shipping production builds.
 
 **End of AGENT.md**

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -3,4 +3,5 @@ export * from './ws/move.js';
 export * from './ws/room.js';
 export * from './ws/auth.js';
 export * from './ws/chat.js';
+export * from './ws/item.js';
 export * from './openapi/auth.js';

--- a/packages/schemas/src/ws/item.ts
+++ b/packages/schemas/src/ws/item.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+import { buildEnvelopeSchema } from './envelope.js';
+
+const identifierSchema = z.string().min(1, 'id required');
+const tileCoordinateSchema = z.number().int().min(0, 'coordinate must be non-negative');
+const roomSeqSchema = z.number().int().min(0, 'roomSeq must be non-negative');
+
+export const roomItemSchema = z.object({
+  id: identifierSchema,
+  name: z.string().min(1, 'item name required'),
+  description: z.string().min(1, 'item description required'),
+  tileX: tileCoordinateSchema,
+  tileY: tileCoordinateSchema,
+  texture: z.string().min(1, 'item texture key required'),
+});
+
+export const inventoryItemSchema = z.object({
+  id: identifierSchema,
+  catalogItemId: identifierSchema,
+  roomItemId: identifierSchema,
+  name: z.string().min(1),
+  description: z.string().min(1),
+  texture: z.string().min(1),
+  acquiredAt: z.string().min(1, 'acquiredAt timestamp required'),
+});
+
+export const itemPickupRequestDataSchema = z.object({
+  itemId: identifierSchema,
+});
+
+export const itemPickupRequestEnvelopeSchema = buildEnvelopeSchema(itemPickupRequestDataSchema);
+
+export const itemPickupOkDataSchema = z.object({
+  itemId: identifierSchema,
+  inventoryItem: inventoryItemSchema,
+  roomSeq: roomSeqSchema,
+});
+
+export const itemPickupOkEnvelopeSchema = buildEnvelopeSchema(itemPickupOkDataSchema);
+
+export const itemPickupErrorCodeSchema = z.enum([
+  'not_available',
+  'wrong_position',
+  'tile_blocked',
+  'unknown_item',
+]);
+
+export const itemPickupErrorDataSchema = z.object({
+  itemId: identifierSchema,
+  code: itemPickupErrorCodeSchema,
+  message: z.string().min(1).optional(),
+  roomSeq: roomSeqSchema.optional(),
+});
+
+export const itemPickupErrorEnvelopeSchema = buildEnvelopeSchema(itemPickupErrorDataSchema);
+
+export const roomItemRemovedDataSchema = z.object({
+  itemId: identifierSchema,
+  roomSeq: roomSeqSchema,
+  pickedUpBy: z
+    .object({
+      id: identifierSchema,
+      username: z.string().min(1),
+    })
+    .optional(),
+});
+
+export const roomItemRemovedEnvelopeSchema = buildEnvelopeSchema(roomItemRemovedDataSchema);
+
+export type RoomItem = z.infer<typeof roomItemSchema>;
+export type InventoryItem = z.infer<typeof inventoryItemSchema>;
+export type ItemPickupErrorCode = z.infer<typeof itemPickupErrorCodeSchema>;

--- a/packages/schemas/src/ws/room.ts
+++ b/packages/schemas/src/ws/room.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { roomItemSchema } from './item.js';
 
 export const roomTileFlagSchema = z.object({
   x: z.number().int().min(0, 'tile.x must be non-negative'),
@@ -23,6 +24,7 @@ export const roomSnapshotSchema = z.object({
   roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
   occupants: z.array(roomOccupantSchema),
   tiles: z.array(roomTileFlagSchema),
+  items: z.array(roomItemSchema),
 });
 
 export const roomOccupantMovedDataSchema = z.object({

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -35,4 +35,24 @@ export interface RoomSnapshot {
     locked: boolean;
     noPickup: boolean;
   }>;
+  items: RoomSnapshotItem[];
+}
+
+export interface RoomSnapshotItem {
+  id: string;
+  name: string;
+  description: string;
+  tileX: number;
+  tileY: number;
+  texture: string;
+}
+
+export interface InventoryItem {
+  id: string;
+  catalogItemId: string;
+  roomItemId: string;
+  name: string;
+  description: string;
+  texture: string;
+  acquiredAt: string;
 }

--- a/packages/server/src/db/items.ts
+++ b/packages/server/src/db/items.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+
+export interface RoomItemRecord {
+  id: string;
+  roomId: string;
+  catalogItemId: string;
+  name: string;
+  description: string;
+  texture: string;
+  tileX: number;
+  tileY: number;
+}
+
+export interface InventoryItemRecord {
+  id: string;
+  userId: string;
+  catalogItemId: string;
+  roomItemId: string;
+  name: string;
+  description: string;
+  texture: string;
+  acquiredAt: Date;
+}
+
+export type ItemPickupErrorCode = 'not_found' | 'already_picked' | 'room_mismatch';
+
+export interface ItemPickupSuccessResult {
+  ok: true;
+  roomItem: RoomItemRecord;
+  inventoryItem: InventoryItemRecord;
+}
+
+export interface ItemPickupErrorResult {
+  ok: false;
+  code: ItemPickupErrorCode;
+  roomItem?: RoomItemRecord;
+}
+
+export type ItemPickupResult = ItemPickupSuccessResult | ItemPickupErrorResult;
+
+export interface ItemStore {
+  listRoomItems(roomId: string): Promise<RoomItemRecord[]>;
+  listInventoryByUser(userId: string): Promise<InventoryItemRecord[]>;
+  pickupRoomItem(params: {
+    roomItemId: string;
+    roomId: string;
+    userId: string;
+  }): Promise<ItemPickupResult>;
+}
+
+const mapRoomItemRow = (row: {
+  id: string;
+  room_id: string;
+  catalog_item_id: string;
+  name: string;
+  description: string;
+  texture_path: string;
+  x: number;
+  y: number;
+}): RoomItemRecord => ({
+  id: row.id,
+  roomId: row.room_id,
+  catalogItemId: row.catalog_item_id,
+  name: row.name,
+  description: row.description,
+  texture: row.texture_path,
+  tileX: row.x,
+  tileY: row.y,
+});
+
+const mapInventoryRow = (row: {
+  id: string;
+  user_id: string;
+  catalog_item_id: string;
+  room_item_id: string;
+  name: string;
+  description: string;
+  texture_path: string;
+  acquired_at: Date;
+}): InventoryItemRecord => ({
+  id: row.id,
+  userId: row.user_id,
+  catalogItemId: row.catalog_item_id,
+  roomItemId: row.room_item_id,
+  name: row.name,
+  description: row.description,
+  texture: row.texture_path,
+  acquiredAt: row.acquired_at,
+});
+
+export const createItemStore = (pool: Pool): ItemStore => {
+  const listRoomItems = async (roomId: string): Promise<RoomItemRecord[]> => {
+    const result = await pool.query({
+      text: `SELECT ri.id, ri.room_id, ri.catalog_item_id, ri.x, ri.y, ic.name, ic.description, ic.texture_path
+               FROM room_item ri
+               JOIN item_catalog ic ON ic.id = ri.catalog_item_id
+              WHERE ri.room_id = $1 AND ri.picked_up_at IS NULL`,
+      values: [roomId],
+    });
+
+    return result.rows.map(mapRoomItemRow);
+  };
+
+  const listInventoryByUser = async (userId: string): Promise<InventoryItemRecord[]> => {
+    const result = await pool.query({
+      text: `SELECT ii.id, ii.user_id, ii.catalog_item_id, ii.room_item_id, ii.acquired_at,
+                    ic.name, ic.description, ic.texture_path
+               FROM inventory_item ii
+               JOIN item_catalog ic ON ic.id = ii.catalog_item_id
+              WHERE ii.user_id = $1
+              ORDER BY ii.acquired_at ASC, ii.id ASC`,
+      values: [userId],
+    });
+
+    return result.rows.map(mapInventoryRow);
+  };
+
+  const pickupRoomItem = async ({
+    roomItemId,
+    roomId,
+    userId,
+  }: {
+    roomItemId: string;
+    roomId: string;
+    userId: string;
+  }): Promise<ItemPickupResult> => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const itemResult = await client.query({
+        text: `SELECT ri.id, ri.room_id, ri.catalog_item_id, ri.x, ri.y, ri.picked_up_at,
+                      ic.name, ic.description, ic.texture_path
+                 FROM room_item ri
+                 JOIN item_catalog ic ON ic.id = ri.catalog_item_id
+                WHERE ri.id = $1
+                FOR UPDATE`,
+        values: [roomItemId],
+      });
+
+      if (itemResult.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return { ok: false, code: 'not_found' };
+      }
+
+      const row = itemResult.rows[0];
+      const roomItem = mapRoomItemRow(row);
+
+      if (row.room_id !== roomId) {
+        await client.query('ROLLBACK');
+        return { ok: false, code: 'room_mismatch', roomItem };
+      }
+
+      if (row.picked_up_at) {
+        await client.query('ROLLBACK');
+        return { ok: false, code: 'already_picked', roomItem };
+      }
+
+      const updateResult = await client.query({
+        text: `UPDATE room_item
+                  SET picked_up_at = now(), picked_up_by = $2
+                WHERE id = $1 AND picked_up_at IS NULL`,
+        values: [roomItemId, userId],
+      });
+
+      if (updateResult.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return { ok: false, code: 'already_picked', roomItem };
+      }
+
+      await client.query({
+        text: `INSERT INTO inventory_item (id, user_id, catalog_item_id, room_item_id)
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (room_item_id) DO NOTHING`,
+        values: [randomUUID(), userId, row.catalog_item_id, row.id],
+      });
+
+      const inventoryLookup = await client.query({
+        text: `SELECT ii.id, ii.user_id, ii.catalog_item_id, ii.room_item_id, ii.acquired_at,
+                      ic.name, ic.description, ic.texture_path
+                 FROM inventory_item ii
+                 JOIN item_catalog ic ON ic.id = ii.catalog_item_id
+                WHERE ii.room_item_id = $1
+                LIMIT 1`,
+        values: [row.id],
+      });
+
+      if (inventoryLookup.rowCount === 0) {
+        await client.query('ROLLBACK');
+        throw new Error(`Inventory record missing after pickup for item ${row.id}`);
+      }
+
+      await client.query('COMMIT');
+
+      return {
+        ok: true,
+        roomItem,
+        inventoryItem: mapInventoryRow(inventoryLookup.rows[0]),
+      };
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  };
+
+  return {
+    listRoomItems,
+    listInventoryByUser,
+    pickupRoomItem,
+  };
+};

--- a/packages/server/src/metrics/registry.ts
+++ b/packages/server/src/metrics/registry.ts
@@ -5,6 +5,7 @@ export interface MetricsBundle {
   activeConnections: Gauge;
   moveEvents: Counter;
   chatEvents: Counter;
+  itemPickups: Counter;
 }
 
 export const createMetricsBundle = (): MetricsBundle => {
@@ -29,10 +30,17 @@ export const createMetricsBundle = (): MetricsBundle => {
     registers: [registry],
   });
 
+  const itemPickups = new Counter({
+    name: 'bitby_item_pickups_total',
+    help: 'Count of successful item pickup events',
+    registers: [registry],
+  });
+
   return {
     registry,
     activeConnections,
     moveEvents,
     chatEvents,
+    itemPickups,
   };
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,6 +11,7 @@ import { runMigrations } from './db/migrations.js';
 import { createUserStore } from './auth/store.js';
 import { createRoomStore } from './db/rooms.js';
 import { createChatStore } from './db/chat.js';
+import { createItemStore } from './db/items.js';
 import { createRoomPubSub } from './redis/pubsub.js';
 import { createMetricsBundle } from './metrics/registry.js';
 import { createRealtimeServer } from './ws/connection.js';
@@ -39,6 +40,7 @@ export const createServer = async ({
   const userStore = createUserStore(pool);
   const roomStore = createRoomStore(pool);
   const chatStore = createChatStore(pool);
+  const itemStore = createItemStore(pool);
   const metrics = createMetricsBundle();
   const instanceId = randomUUID();
   const pubsub = await createRoomPubSub({
@@ -50,6 +52,7 @@ export const createServer = async ({
     config,
     roomStore,
     chatStore,
+    itemStore,
     pubsub,
     metrics,
   });


### PR DESCRIPTION
## Summary
- add Postgres item catalog and inventory migrations plus realtime server handlers for `item:pickup` with optimistic removal, authoritative validation, and metrics
- extend the client realtime hook and UI so the "Saml Op" control emits pickup envelopes, tracks pending/success/error states, and reflects authoritative acknowledgements
- document the new pickup pipeline and update AGENT/README next steps to focus on typing bubbles, context menus, and inventory UI follow-ups

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d47459261883339cc3c112f34873af