### PR TITLE
feat: add context menus for grid tiles, items, and avatars

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -485,27 +485,29 @@ When implementing, **Codex should**:
 
 1) Wire the item pickup loop (server validation, inventory persistence, optimistic UI) so the panel’s “Saml Op” control reflects authoritative acknowledgements.
 2) Add realtime typing bubbles and chat bubble rendering on the canvas while persisting the chat drawer’s system-message preference per user.
-3) Build right-click context menus for tiles, items, and avatars with the gating rules outlined in the Master Spec (Info/Saml Op, player actions).
+3) Wire the new right-click context menus into authoritative flows so Info/Saml Op respect server state and avatar actions trigger real profile/trade/mute/report plumbing.
 4) Extend the admin quick menu so each toggle calls the authoritative API (lock/noPickup, latency trace) and persists dev overrides via Postgres/Redis.
 5) Establish automated integration/E2E tests that exercise auth → chat → move → item flows against the Postgres/Redis stack and wire them into CI.
 6) Audit `[realtime]` debug logging before release (demote, gate, or remove) so production builds ship without noisy console output.
 
 ---
 
-## 24) Progress Snapshot — 2025-09-25
+## 24) Progress Snapshot — 2025-09-24
 
 - ✅ `useRealtimeConnection` authenticates via `/auth/login`, maintains heartbeats, hydrates the room snapshot, streams historical chat, appends live `chat:new` envelopes, and exposes a composer that emits `chat:send` while the blocking overlay clears automatically after reconnect.
 - ✅ The React client now renders seeded room items beneath avatars, tracks per-item hit boxes, routes selections into the right panel’s item info view, and honours the chat drawer’s system-message toggle alongside the existing admin quick toggles and movement gating.
+- ✅ Right-click context menus now surface tile, item, and avatar actions per spec, gating “Saml Op” to same-tile, non-`noPickup` squares while leaving avatar actions ready for future authority wiring and keeping the admin quick toggles non-blocking.
+- ✅ The “Saml Op” button now emits real `item:pickup` envelopes; the server validates tile/noPickup rules, persists the transfer to Postgres, increments `roomSeq`, broadcasts `room:item_removed`, and the client performs optimistic removal with pending/success/error copy while restoring items on authoritative rejection.
 - ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat history to Postgres, relays cross-instance chat through Redis pub/sub, and exposes `/healthz`, `/readyz`, and `/metrics` endpoints instrumented with Prometheus counters.
 - ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, and `chat` plus an OpenAPI document for `/auth/login`, keeping both tiers on a single contract for realtime and REST payloads.
 - ✅ Workspace scripts rebuild shared schemas before Vite launches, and lint/typecheck/test/build workflows cover the new chat, item, and observability codepaths.
-- Latest connectivity screenshot with chat + item panel: `browser:/invocations/nkjxmmlj/artifacts/artifacts/bitby-connected.png`.
+- Latest connectivity screenshot with chat + item panel: `browser:/invocations/mdaqbhvm/artifacts/artifacts/context-menu-connected.png`.
 
 ### Immediate Next Focus
 
-1. Wire the pickup pipeline end-to-end (server validation, inventory persistence, optimistic UI) so the right panel button reflects authoritative acknowledgements.
+1. Surface the newly persisted inventory/backpack data in the UI so pickups appear instantly after authoritative acknowledgement.
 2. Add typing bubbles and chat bubble rendering on the canvas while persisting the system-message preference.
-3. Implement the spec’d context menus for tiles/items/avatars and extend the admin quick menu to call authoritative toggles.
+3. Promote the new context menu actions from local stubs to authoritative flows (profile panel, trade bootstrap, mute/report) while preserving the gating rules.
 4. Stand up integration/E2E tests that drive auth → chat → move → item flows against Postgres/Redis and gate CI on them.
 5. Gate or demote the `[realtime]` debug logging before shipping production builds.
 

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -869,6 +869,188 @@ body {
   outline-offset: 2px;
 }
 
+.context-menu {
+  position: fixed;
+  z-index: 140;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(17, 24, 36, 0.95);
+  border: 1px solid rgba(122, 209, 255, 0.32);
+  border-radius: 12px;
+  box-shadow: 0 22px 48px rgba(6, 14, 26, 0.48);
+  color: #eaf2ff;
+  max-width: 320px;
+  min-width: 220px;
+  pointer-events: auto;
+  backdrop-filter: blur(10px);
+  transition: opacity 120ms ease;
+}
+
+.context-menu__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.context-menu__title {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.context-menu__subtitle {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(122, 209, 255, 0.7);
+  margin: 0;
+}
+
+.context-menu__roles {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: rgba(234, 242, 255, 0.55);
+}
+
+.context-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.context-menu__list-item {
+  background: rgba(234, 242, 255, 0.06);
+  border: 1px solid rgba(122, 209, 255, 0.18);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.context-menu__list-item--focused {
+  border-color: rgba(122, 209, 255, 0.45);
+  box-shadow: 0 0 0 2px rgba(122, 209, 255, 0.22);
+}
+
+.context-menu__item-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.context-menu__item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #eaf2ff;
+}
+
+.context-menu__item-meta {
+  font-size: 12px;
+  color: rgba(234, 242, 255, 0.65);
+  letter-spacing: 0.02em;
+}
+
+.context-menu__actions {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.context-menu__actions button {
+  border-radius: 8px;
+  border: 1px solid rgba(122, 209, 255, 0.28);
+  background: rgba(122, 209, 255, 0.18);
+  color: #eaf2ff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+}
+
+.context-menu__actions button:hover,
+.context-menu__actions button:focus-visible {
+  background: rgba(122, 209, 255, 0.3);
+  border-color: rgba(122, 209, 255, 0.6);
+  color: #ffffff;
+}
+
+.context-menu__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  background: rgba(122, 209, 255, 0.12);
+  border-color: rgba(122, 209, 255, 0.14);
+}
+
+.context-menu__actions button:focus-visible {
+  outline: 2px solid rgba(122, 209, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.context-menu__status {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: rgba(234, 242, 255, 0.68);
+}
+
+.context-menu__empty {
+  margin: 0;
+  padding: 10px 12px;
+  background: rgba(234, 242, 255, 0.06);
+  border-radius: 10px;
+  border: 1px dashed rgba(122, 209, 255, 0.24);
+  font-size: 12px;
+  letter-spacing: 0.03em;
+  text-align: center;
+}
+
+.context-menu__list--actions {
+  gap: 6px;
+}
+
+.context-menu__list--actions .context-menu__list-item {
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.context-menu__list--actions .context-menu__list-item button {
+  width: 100%;
+  padding: 10px 12px;
+  background: rgba(234, 242, 255, 0.08);
+  border: 1px solid rgba(122, 209, 255, 0.22);
+  border-radius: 10px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.context-menu__list--actions .context-menu__list-item button:hover,
+.context-menu__list--actions .context-menu__list-item button:focus-visible {
+  background: rgba(122, 209, 255, 0.22);
+  border-color: rgba(122, 209, 255, 0.5);
+}
+
+.context-menu__list--actions .context-menu__list-item button:disabled {
+  opacity: 0.45;
+  background: rgba(234, 242, 255, 0.06);
+  border-color: rgba(122, 209, 255, 0.16);
+}
+
 .has-tooltip::after {
   content: attr(data-tooltip);
   position: absolute;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -3,4 +3,5 @@ export * from './ws/move.js';
 export * from './ws/room.js';
 export * from './ws/auth.js';
 export * from './ws/chat.js';
+export * from './ws/items.js';
 export * from './openapi/auth.js';

--- a/packages/schemas/src/ws/items.ts
+++ b/packages/schemas/src/ws/items.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+import { roomItemSchema } from './room.js';
+
+export const inventoryItemSchema = z.object({
+  id: z.string().min(1, 'inventory id required'),
+  roomItemId: z.string().min(1, 'room item id required'),
+  roomId: z.string().min(1, 'room id required'),
+  name: z.string().min(1, 'inventory item name required'),
+  description: z.string().min(1, 'inventory item description required'),
+  textureKey: z.string().min(1, 'inventory item texture key required'),
+  acquiredAt: z.string().min(1, 'inventory acquiredAt timestamp required'),
+});
+
+export const itemPickupRequestDataSchema = z.object({
+  itemId: z.string().min(1, 'itemId is required'),
+});
+
+export const itemPickupOkDataSchema = z.object({
+  itemId: z.string().min(1, 'itemId is required'),
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+  inventoryItem: inventoryItemSchema,
+});
+
+export const itemPickupErrorCodeSchema = z.enum([
+  'validation_failed',
+  'not_in_room',
+  'not_found',
+  'tile_blocked',
+  'not_on_tile',
+  'already_picked_up',
+  'persist_failed',
+]);
+
+export const itemPickupErrorDataSchema = z.object({
+  itemId: z.string().min(1, 'itemId is required'),
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+  code: itemPickupErrorCodeSchema,
+  message: z.string().min(1, 'error message is required'),
+});
+
+export const roomItemRemovedDataSchema = z.object({
+  itemId: z.string().min(1, 'itemId is required'),
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+});
+
+export type InventoryItem = z.infer<typeof inventoryItemSchema>;
+export type ItemPickupRequestData = z.infer<typeof itemPickupRequestDataSchema>;
+export type ItemPickupOkData = z.infer<typeof itemPickupOkDataSchema>;
+export type ItemPickupErrorData = z.infer<typeof itemPickupErrorDataSchema>;
+export type ItemPickupErrorCode = z.infer<typeof itemPickupErrorCodeSchema>;
+export type RoomItemRemovedData = z.infer<typeof roomItemRemovedDataSchema>;
+
+export { roomItemSchema };

--- a/packages/schemas/src/ws/room.ts
+++ b/packages/schemas/src/ws/room.ts
@@ -17,12 +17,22 @@ export const roomOccupantSchema = z.object({
   }),
 });
 
+export const roomItemSchema = z.object({
+  id: z.string().min(1, 'item id required'),
+  name: z.string().min(1, 'item name required'),
+  description: z.string().min(1, 'item description required'),
+  tileX: z.number().int().min(0, 'item tileX must be non-negative'),
+  tileY: z.number().int().min(0, 'item tileY must be non-negative'),
+  textureKey: z.string().min(1, 'item texture key required'),
+});
+
 export const roomSnapshotSchema = z.object({
   id: z.string().min(1, 'room id required'),
   name: z.string().min(1, 'room name required'),
   roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
   occupants: z.array(roomOccupantSchema),
   tiles: z.array(roomTileFlagSchema),
+  items: z.array(roomItemSchema),
 });
 
 export const roomOccupantMovedDataSchema = z.object({
@@ -44,5 +54,6 @@ export const roomOccupantLeftDataSchema = z.object({
 export type RoomTileFlag = z.infer<typeof roomTileFlagSchema>;
 export type RoomOccupant = z.infer<typeof roomOccupantSchema>;
 export type RoomSnapshot = z.infer<typeof roomSnapshotSchema>;
+export type RoomItem = z.infer<typeof roomItemSchema>;
 export type RoomOccupantMovedData = z.infer<typeof roomOccupantMovedDataSchema>;
 export type RoomOccupantLeftData = z.infer<typeof roomOccupantLeftDataSchema>;

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -35,4 +35,12 @@ export interface RoomSnapshot {
     locked: boolean;
     noPickup: boolean;
   }>;
+  items: Array<{
+    id: string;
+    name: string;
+    description: string;
+    tileX: number;
+    tileY: number;
+    textureKey: string;
+  }>;
 }

--- a/packages/server/src/db/items.ts
+++ b/packages/server/src/db/items.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool, PoolClient } from 'pg';
+
+export interface RoomItemRecord {
+  id: string;
+  roomId: string;
+  name: string;
+  description: string;
+  textureKey: string;
+  tileX: number;
+  tileY: number;
+  pickedUpAt: Date | null;
+  pickedUpBy: string | null;
+}
+
+export interface InventoryItemRecord {
+  id: string;
+  userId: string;
+  roomItemId: string;
+  roomId: string;
+  name: string;
+  description: string;
+  textureKey: string;
+  acquiredAt: Date;
+}
+
+export type ItemPickupFailureReason =
+  | 'not_found'
+  | 'already_picked_up'
+  | 'persist_failed';
+
+export type ItemPickupResult =
+  | { ok: true; item: RoomItemRecord; inventoryItem: InventoryItemRecord }
+  | { ok: false; reason: ItemPickupFailureReason; item?: RoomItemRecord | null };
+
+export interface ItemStore {
+  listRoomItems(roomId: string): Promise<RoomItemRecord[]>;
+  listInventoryForUser(userId: string): Promise<InventoryItemRecord[]>;
+  attemptPickup(
+    params: { itemId: string; userId: string; roomId: string },
+  ): Promise<ItemPickupResult>;
+}
+
+const mapRoomItemRow = (row: {
+  id: string;
+  room_id: string;
+  name: string;
+  description: string;
+  texture_key: string;
+  tile_x: number;
+  tile_y: number;
+  picked_up_at: Date | string | null;
+  picked_up_by: string | null;
+}): RoomItemRecord => ({
+  id: row.id,
+  roomId: row.room_id,
+  name: row.name,
+  description: row.description,
+  textureKey: row.texture_key,
+  tileX: row.tile_x,
+  tileY: row.tile_y,
+  pickedUpAt: row.picked_up_at ? new Date(row.picked_up_at) : null,
+  pickedUpBy: row.picked_up_by,
+});
+
+const mapInventoryRow = (row: {
+  id: string;
+  user_id: string;
+  room_item_id: string;
+  room_id: string;
+  acquired_at: Date | string;
+}): {
+  id: string;
+  userId: string;
+  roomItemId: string;
+  roomId: string;
+  acquiredAt: Date;
+} => ({
+  id: row.id,
+  userId: row.user_id,
+  roomItemId: row.room_item_id,
+  roomId: row.room_id,
+  acquiredAt: new Date(row.acquired_at),
+});
+
+const withTransaction = async <T>(pool: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackError) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to rollback item transaction', rollbackError);
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+export const createItemStore = (pool: Pool): ItemStore => {
+  const listRoomItems = async (roomId: string): Promise<RoomItemRecord[]> => {
+    const result = await pool.query<{
+      id: string;
+      room_id: string;
+      name: string;
+      description: string;
+      texture_key: string;
+      tile_x: number;
+      tile_y: number;
+      picked_up_at: Date | string | null;
+      picked_up_by: string | null;
+    }>(
+      `SELECT id, room_id, name, description, texture_key, tile_x, tile_y, picked_up_at, picked_up_by
+         FROM room_item
+        WHERE room_id = $1 AND picked_up_at IS NULL
+        ORDER BY tile_y ASC, tile_x ASC`,
+      [roomId],
+    );
+
+    return result.rows.map((row) => mapRoomItemRow(row));
+  };
+
+  const listInventoryForUser = async (userId: string): Promise<InventoryItemRecord[]> => {
+    const result = await pool.query<{
+      id: string;
+      user_id: string;
+      room_item_id: string;
+      room_id: string;
+      acquired_at: Date | string;
+      name: string;
+      description: string;
+      texture_key: string;
+    }>(
+      `SELECT uii.id, uii.user_id, uii.room_item_id, uii.room_id, uii.acquired_at,
+              ri.name, ri.description, ri.texture_key
+         FROM user_inventory_item uii
+         JOIN room_item ri ON ri.id = uii.room_item_id
+        WHERE uii.user_id = $1
+        ORDER BY uii.acquired_at DESC, uii.id DESC`,
+      [userId],
+    );
+
+    return result.rows.map((row) => ({
+      ...mapInventoryRow(row),
+      name: row.name,
+      description: row.description,
+      textureKey: row.texture_key,
+    }));
+  };
+
+  const attemptPickup = async ({
+    itemId,
+    userId,
+    roomId,
+  }: {
+    itemId: string;
+    userId: string;
+    roomId: string;
+  }): Promise<ItemPickupResult> =>
+    withTransaction(pool, async (client) => {
+      const itemResult = await client.query<{
+        id: string;
+        room_id: string;
+        name: string;
+        description: string;
+        texture_key: string;
+        tile_x: number;
+        tile_y: number;
+        picked_up_at: Date | string | null;
+        picked_up_by: string | null;
+      }>(
+        `SELECT id, room_id, name, description, texture_key, tile_x, tile_y, picked_up_at, picked_up_by
+           FROM room_item
+          WHERE id = $1
+          FOR UPDATE`,
+        [itemId],
+      );
+
+      if (itemResult.rowCount === 0) {
+        return { ok: false, reason: 'not_found' };
+      }
+
+      const item = mapRoomItemRow(itemResult.rows[0]);
+      if (item.roomId !== roomId) {
+        return { ok: false, reason: 'not_found' };
+      }
+
+      if (item.pickedUpAt) {
+        return { ok: false, reason: 'already_picked_up', item };
+      }
+
+      const updatedItemResult = await client.query<{
+        id: string;
+        room_id: string;
+        name: string;
+        description: string;
+        texture_key: string;
+        tile_x: number;
+        tile_y: number;
+        picked_up_at: Date | string | null;
+        picked_up_by: string | null;
+      }>(
+        `UPDATE room_item
+            SET picked_up_at = now(),
+                picked_up_by = $2,
+                updated_at = now()
+          WHERE id = $1
+          RETURNING id, room_id, name, description, texture_key, tile_x, tile_y, picked_up_at, picked_up_by`,
+        [itemId, userId],
+      );
+
+      if (updatedItemResult.rowCount === 0) {
+        return { ok: false, reason: 'persist_failed' };
+      }
+
+      const updatedItem = mapRoomItemRow(updatedItemResult.rows[0]);
+
+      const inventoryId = randomUUID();
+      const inventoryInsertResult = await client.query<{
+        id: string;
+        user_id: string;
+        room_item_id: string;
+        room_id: string;
+        acquired_at: Date | string;
+      }>(
+        `INSERT INTO user_inventory_item (id, user_id, room_item_id, room_id)
+             VALUES ($1, $2, $3, $4)
+          RETURNING id, user_id, room_item_id, room_id, acquired_at`,
+        [inventoryId, userId, updatedItem.id, updatedItem.roomId],
+      );
+
+      if (inventoryInsertResult.rowCount === 0) {
+        return { ok: false, reason: 'persist_failed', item: updatedItem };
+      }
+
+      const inventoryBase = mapInventoryRow(inventoryInsertResult.rows[0]);
+
+      const inventoryItem: InventoryItemRecord = {
+        ...inventoryBase,
+        name: updatedItem.name,
+        description: updatedItem.description,
+        textureKey: updatedItem.textureKey,
+      };
+
+      return { ok: true, item: updatedItem, inventoryItem };
+    });
+
+  return {
+    listRoomItems,
+    listInventoryForUser,
+    attemptPickup,
+  };
+};

--- a/packages/server/src/metrics/registry.ts
+++ b/packages/server/src/metrics/registry.ts
@@ -5,6 +5,7 @@ export interface MetricsBundle {
   activeConnections: Gauge;
   moveEvents: Counter;
   chatEvents: Counter;
+  itemPickups: Counter;
 }
 
 export const createMetricsBundle = (): MetricsBundle => {
@@ -29,10 +30,17 @@ export const createMetricsBundle = (): MetricsBundle => {
     registers: [registry],
   });
 
+  const itemPickups = new Counter({
+    name: 'bitby_item_pickups_total',
+    help: 'Count of successful item pickups',
+    registers: [registry],
+  });
+
   return {
     registry,
     activeConnections,
     moveEvents,
     chatEvents,
+    itemPickups,
   };
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,6 +11,7 @@ import { runMigrations } from './db/migrations.js';
 import { createUserStore } from './auth/store.js';
 import { createRoomStore } from './db/rooms.js';
 import { createChatStore } from './db/chat.js';
+import { createItemStore } from './db/items.js';
 import { createRoomPubSub } from './redis/pubsub.js';
 import { createMetricsBundle } from './metrics/registry.js';
 import { createRealtimeServer } from './ws/connection.js';
@@ -39,6 +40,7 @@ export const createServer = async ({
   const userStore = createUserStore(pool);
   const roomStore = createRoomStore(pool);
   const chatStore = createChatStore(pool);
+  const itemStore = createItemStore(pool);
   const metrics = createMetricsBundle();
   const instanceId = randomUUID();
   const pubsub = await createRoomPubSub({
@@ -50,6 +52,7 @@ export const createServer = async ({
     config,
     roomStore,
     chatStore,
+    itemStore,
     pubsub,
     metrics,
   });


### PR DESCRIPTION
## Summary
- add reusable context-menu overlay for tiles, items, and avatars with spec-driven gating and keyboard navigation
- extend GridCanvas event handling to surface right-click payloads for items and occupants while keeping admin toggles interactive
- document the new context menus in the README/AGENT handoff notes and style them according to the stage chrome tokens

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d47459261883339cc3c112f34873af