### PR TITLE
Wire admin quick menu to authoritative state

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -497,19 +497,20 @@ When implementing, **Codex should**:
 - ✅ `useRealtimeConnection` authenticates via `/auth/login`, maintains heartbeats, hydrates the room snapshot, streams historical chat, appends live `chat:new` envelopes, and exposes a composer that emits `chat:send` while the blocking overlay clears automatically after reconnect.
 - ✅ The React client now renders seeded room items beneath avatars, tracks per-item hit boxes, routes selections into the right panel’s item info view, and overlays realtime typing previews plus authoritative chat bubbles on the canvas while the chat composer listens globally (type anywhere, Enter to send, Esc to cancel) and honours the chat drawer’s per-user system-message preference alongside the admin quick toggles and movement gating.
 - ✅ Right-click context menus now surface tile, item, and avatar actions per spec, gating “Saml Op” to same-tile, non-`noPickup` squares while leaving avatar actions ready for future authority wiring and keeping the admin quick toggles non-blocking.
+- ✅ Admin quick-menu toggles hydrate from the realtime handshake, PATCH `/admin/rooms/:roomId/state`, persist overrides to Postgres, and fan out through Redis so concurrent clients stay in sync while buttons reflect pending server writes.
 - ✅ The “Saml Op” button now emits real `item:pickup` envelopes; the server validates tile/noPickup rules, persists the transfer to Postgres, increments `roomSeq`, broadcasts `room:item_removed`, and the client performs optimistic removal with pending/success/error copy while restoring items on authoritative rejection.
-- ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat history to Postgres, relays cross-instance chat through Redis pub/sub, persists per-user chat drawer preferences, and exposes `/healthz`, `/readyz`, and `/metrics` endpoints instrumented with Prometheus counters.
-- ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, and `chat` plus an OpenAPI document for `/auth/login`, keeping both tiers on a single contract for realtime and REST payloads.
+- ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat history to Postgres, relays cross-instance chat through Redis pub/sub, persists per-user chat drawer preferences, and now exposes `/healthz`, `/readyz`, `/metrics`, plus `/admin/rooms/:roomId/state` for authoritative admin toggles.
+- ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, `chat`, and the admin quick-menu state plus OpenAPI documents for `/auth/login` and `/admin/rooms/:roomId/state`, keeping both tiers on a single contract for realtime and REST payloads.
 - ✅ Workspace scripts rebuild shared schemas before Vite launches, and lint/typecheck/test/build workflows cover the new chat, item, and observability codepaths.
 - ✅ `@bitby/server` now ships a Vitest-backed integration/E2E suite that boots Postgres/Redis via Testcontainers (or `BITBY_TEST_STACK=external`) and drives auth, heartbeat, reconnect, typing, chat, movement, and item pickup flows to guard regressions across the realtime pipeline.
-- Latest connectivity screenshot with chat + item panel: `browser:/invocations/kmpruogw/artifacts/artifacts/connected-room.png`.
+- Latest connectivity screenshot with chat + admin toggles: `browser:/invocations/wlrtdird/artifacts/artifacts/connected-room.png`.
 - **Infra fallback:** When Docker is unavailable, install Postgres/Redis via `apt` (`sudo apt-get install -y postgresql redis-server`), start them with `sudo pg_ctlcluster 16 main start` and `redis-server --daemonize yes`, then create the `bitby` role/database before launching the server (see README §L6b).
 
 ### Immediate Next Focus
 
 1. Surface the newly persisted inventory/backpack data in the UI so pickups appear instantly after authoritative acknowledgement.
 2. Promote the new context menu actions from local stubs to authoritative flows (profile panel, trade bootstrap, mute/report) while preserving the gating rules.
-3. Extend the admin quick menu so authoritative toggles (lock/noPickup, latency trace) persist via Postgres/Redis.
+3. Backfill admin quick-menu coverage: add REST/Redis integration tests, reconcile pending-state UX for reconnects, and capture concurrency cases.
 4. Gate or demote the `[realtime]` debug logging before shipping production builds.
 
 **End of AGENT.md**

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -4,4 +4,6 @@ export * from './ws/room.js';
 export * from './ws/auth.js';
 export * from './ws/chat.js';
 export * from './ws/items.js';
+export * from './ws/admin.js';
 export * from './openapi/auth.js';
+export * from './openapi/admin.js';

--- a/packages/schemas/src/openapi/admin.ts
+++ b/packages/schemas/src/openapi/admin.ts
@@ -1,0 +1,132 @@
+import type { OpenAPIV3_1 } from 'openapi-types';
+
+export const adminStateOpenApiDocument: OpenAPIV3_1.Document = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Bitby Admin API',
+    version: '0.1.0',
+    description: 'Administrative endpoints for development overrides.',
+  },
+  paths: {
+    '/admin/rooms/{roomId}/state': {
+      get: {
+        summary: 'Fetch the current admin quick menu state for a room',
+        operationId: 'getAdminState',
+        parameters: [
+          {
+            name: 'roomId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Admin state payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: [
+                    'showGrid',
+                    'showHoverWhenGridHidden',
+                    'moveAnimationsEnabled',
+                    'latencyTraceEnabled',
+                    'lockTilesEnabled',
+                    'noPickupEnabled',
+                    'updatedAt',
+                  ],
+                  properties: {
+                    showGrid: { type: 'boolean' },
+                    showHoverWhenGridHidden: { type: 'boolean' },
+                    moveAnimationsEnabled: { type: 'boolean' },
+                    latencyTraceEnabled: { type: 'boolean' },
+                    lockTilesEnabled: { type: 'boolean' },
+                    noPickupEnabled: { type: 'boolean' },
+                    updatedAt: { type: 'string', format: 'date-time' },
+                    updatedBy: { type: 'string', nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          '401': {
+            description: 'Missing or invalid bearer token',
+          },
+          '404': {
+            description: 'Room not found',
+          },
+        },
+      },
+      patch: {
+        summary: 'Update one or more admin quick menu flags',
+        operationId: 'updateAdminState',
+        parameters: [
+          {
+            name: 'roomId',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  showGrid: { type: 'boolean' },
+                  showHoverWhenGridHidden: { type: 'boolean' },
+                  moveAnimationsEnabled: { type: 'boolean' },
+                  latencyTraceEnabled: { type: 'boolean' },
+                  lockTilesEnabled: { type: 'boolean' },
+                  noPickupEnabled: { type: 'boolean' },
+                },
+                minProperties: 1,
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Updated admin state',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: [
+                    'showGrid',
+                    'showHoverWhenGridHidden',
+                    'moveAnimationsEnabled',
+                    'latencyTraceEnabled',
+                    'lockTilesEnabled',
+                    'noPickupEnabled',
+                    'updatedAt',
+                  ],
+                  properties: {
+                    showGrid: { type: 'boolean' },
+                    showHoverWhenGridHidden: { type: 'boolean' },
+                    moveAnimationsEnabled: { type: 'boolean' },
+                    latencyTraceEnabled: { type: 'boolean' },
+                    lockTilesEnabled: { type: 'boolean' },
+                    noPickupEnabled: { type: 'boolean' },
+                    updatedAt: { type: 'string', format: 'date-time' },
+                    updatedBy: { type: 'string', nullable: true },
+                  },
+                },
+              },
+            },
+          },
+          '400': { description: 'Payload rejected' },
+          '401': { description: 'Missing or invalid bearer token' },
+          '404': { description: 'Room not found' },
+        },
+      },
+    },
+  },
+  components: {},
+};

--- a/packages/schemas/src/ws/admin.ts
+++ b/packages/schemas/src/ws/admin.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const adminQuickMenuStateSchema = z.object({
+  showGrid: z.boolean(),
+  showHoverWhenGridHidden: z.boolean(),
+  moveAnimationsEnabled: z.boolean(),
+  latencyTraceEnabled: z.boolean(),
+  lockTilesEnabled: z.boolean(),
+  noPickupEnabled: z.boolean(),
+  updatedAt: z.string().datetime({ message: 'updatedAt must be an ISO timestamp' }),
+  updatedBy: z.string().min(1).nullable().optional(),
+});
+
+export const adminQuickMenuUpdateSchema = adminQuickMenuStateSchema
+  .omit({ updatedAt: true, updatedBy: true })
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one admin quick menu flag must be provided',
+  });
+
+export type AdminQuickMenuState = z.infer<typeof adminQuickMenuStateSchema>;
+export type AdminQuickMenuUpdate = z.infer<typeof adminQuickMenuUpdateSchema>;

--- a/packages/server/src/api/admin.ts
+++ b/packages/server/src/api/admin.ts
@@ -1,0 +1,122 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { adminQuickMenuUpdateSchema, type AdminQuickMenuUpdate } from '@bitby/schemas';
+import type { ServerConfig } from '../config.js';
+import type { AdminStateStore } from '../db/admin.js';
+import { toAdminStatePayload } from '../db/admin.js';
+import type { RoomStore } from '../db/rooms.js';
+import type { RoomPubSub, RoomAdminEvent } from '../redis/pubsub.js';
+import type { RealtimeServer } from '../ws/connection.js';
+import { decodeToken } from '../auth/jwt.js';
+import type { AuthenticatedUser } from '../auth/types.js';
+
+const paramsSchema = z.object({
+  roomId: z.string().uuid('roomId must be a valid UUID'),
+});
+
+interface AdminRoutesOptions {
+  config: ServerConfig;
+  adminStateStore: AdminStateStore;
+  roomStore: RoomStore;
+  pubsub: RoomPubSub;
+  realtime: RealtimeServer;
+}
+
+const ensureAuthenticated = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  config: ServerConfig,
+): Promise<AuthenticatedUser | null> => {
+  const header = request.headers.authorization;
+  if (!header || typeof header !== 'string' || !header.startsWith('Bearer ')) {
+    await reply.code(401).send({ message: 'Missing bearer token' });
+    return null;
+  }
+
+  const token = header.slice('Bearer '.length).trim();
+  if (!token) {
+    await reply.code(401).send({ message: 'Missing bearer token' });
+    return null;
+  }
+
+  try {
+    return decodeToken(token, config);
+  } catch {
+    await reply.code(401).send({ message: 'Invalid bearer token' });
+    return null;
+  }
+};
+
+export const adminRoutes: FastifyPluginAsync<AdminRoutesOptions> = async (
+  app,
+  options,
+) => {
+  const { config, adminStateStore, roomStore, pubsub, realtime } = options;
+
+  app.get('/admin/rooms/:roomId/state', async (request, reply) => {
+    const user = await ensureAuthenticated(request, reply, config);
+    if (!user) {
+      return;
+    }
+
+    const parsedParams = paramsSchema.safeParse(request.params);
+    if (!parsedParams.success) {
+      await reply.code(400).send({ message: 'Invalid room identifier' });
+      return;
+    }
+
+    const room = await roomStore.getRoomById(parsedParams.data.roomId);
+    if (!room) {
+      await reply.code(404).send({ message: 'Room not found' });
+      return;
+    }
+
+    const state = await adminStateStore.getRoomState(room.id);
+    await reply.send(toAdminStatePayload(state));
+  });
+
+  app.patch('/admin/rooms/:roomId/state', async (request, reply) => {
+    const user = await ensureAuthenticated(request, reply, config);
+    if (!user) {
+      return;
+    }
+
+    const parsedParams = paramsSchema.safeParse(request.params);
+    if (!parsedParams.success) {
+      await reply.code(400).send({ message: 'Invalid room identifier' });
+      return;
+    }
+
+    const room = await roomStore.getRoomById(parsedParams.data.roomId);
+    if (!room) {
+      await reply.code(404).send({ message: 'Room not found' });
+      return;
+    }
+
+    const parsedBody = adminQuickMenuUpdateSchema.safeParse(request.body);
+    if (!parsedBody.success) {
+      await reply.code(400).send({
+        message: 'Invalid admin state payload',
+        issues: parsedBody.error.issues,
+      });
+      return;
+    }
+
+    const update: AdminQuickMenuUpdate = parsedBody.data;
+
+    const updated = await adminStateStore.updateRoomState(room.id, update, {
+      updatedBy: user.id,
+    });
+    realtime.applyAdminStateUpdate(updated);
+
+    const payload = toAdminStatePayload(updated);
+    const event: RoomAdminEvent = {
+      type: 'admin:state',
+      roomId: room.id,
+      payload,
+    };
+    await pubsub.publishAdminState(event);
+
+    await reply.send(payload);
+  });
+};

--- a/packages/server/src/db/admin.ts
+++ b/packages/server/src/db/admin.ts
@@ -1,0 +1,219 @@
+import type { Pool } from 'pg';
+import type { AdminQuickMenuState } from '@bitby/schemas';
+
+export interface RoomAdminStateRecord {
+  roomId: string;
+  showGrid: boolean;
+  showHoverWhenGridHidden: boolean;
+  moveAnimationsEnabled: boolean;
+  latencyTraceEnabled: boolean;
+  lockTilesEnabled: boolean;
+  noPickupEnabled: boolean;
+  updatedAt: Date;
+  updatedBy: string | null;
+}
+
+export interface UpdateAdminStateInput {
+  showGrid?: boolean;
+  showHoverWhenGridHidden?: boolean;
+  moveAnimationsEnabled?: boolean;
+  latencyTraceEnabled?: boolean;
+  lockTilesEnabled?: boolean;
+  noPickupEnabled?: boolean;
+}
+
+export interface AdminStateStore {
+  getRoomState(roomId: string): Promise<RoomAdminStateRecord>;
+  updateRoomState(
+    roomId: string,
+    patch: UpdateAdminStateInput,
+    options: { updatedBy?: string | null }
+  ): Promise<RoomAdminStateRecord>;
+}
+
+const mapRow = (row: {
+  room_id: string;
+  show_grid: boolean;
+  show_hover_when_grid_hidden: boolean;
+  move_animations_enabled: boolean;
+  latency_trace_enabled: boolean;
+  lock_tiles_enabled: boolean;
+  no_pickup_enabled: boolean;
+  updated_at: Date;
+  updated_by: string | null;
+}): RoomAdminStateRecord => ({
+  roomId: row.room_id,
+  showGrid: row.show_grid,
+  showHoverWhenGridHidden: row.show_hover_when_grid_hidden,
+  moveAnimationsEnabled: row.move_animations_enabled,
+  latencyTraceEnabled: row.latency_trace_enabled,
+  lockTilesEnabled: row.lock_tiles_enabled,
+  noPickupEnabled: row.no_pickup_enabled,
+  updatedAt: row.updated_at,
+  updatedBy: row.updated_by,
+});
+
+export const createAdminStateStore = (pool: Pool): AdminStateStore => {
+  const ensureRow = async (roomId: string): Promise<void> => {
+    await pool.query(
+      `INSERT INTO room_admin_state (room_id)
+         VALUES ($1)
+         ON CONFLICT (room_id) DO NOTHING`,
+      [roomId],
+    );
+  };
+
+  const getRoomState = async (roomId: string): Promise<RoomAdminStateRecord> => {
+    const result = await pool.query<{
+      room_id: string;
+      show_grid: boolean;
+      show_hover_when_grid_hidden: boolean;
+      move_animations_enabled: boolean;
+      latency_trace_enabled: boolean;
+      lock_tiles_enabled: boolean;
+      no_pickup_enabled: boolean;
+      updated_at: Date;
+      updated_by: string | null;
+    }>(
+      `SELECT room_id,
+              show_grid,
+              show_hover_when_grid_hidden,
+              move_animations_enabled,
+              latency_trace_enabled,
+              lock_tiles_enabled,
+              no_pickup_enabled,
+              updated_at,
+              updated_by
+         FROM room_admin_state
+        WHERE room_id = $1
+        LIMIT 1`,
+      [roomId],
+    );
+
+    if (result.rowCount === 0) {
+      await ensureRow(roomId);
+      const retry = await pool.query(
+        `SELECT room_id,
+                show_grid,
+                show_hover_when_grid_hidden,
+                move_animations_enabled,
+                latency_trace_enabled,
+                lock_tiles_enabled,
+                no_pickup_enabled,
+                updated_at,
+                updated_by
+           FROM room_admin_state
+          WHERE room_id = $1
+          LIMIT 1`,
+        [roomId],
+      );
+      if (retry.rowCount === 0) {
+        throw new Error(`Failed to materialise admin state for room ${roomId}`);
+      }
+      return mapRow(retry.rows[0]);
+    }
+
+    return mapRow(result.rows[0]);
+  };
+
+  const updateRoomState = async (
+    roomId: string,
+    patch: UpdateAdminStateInput,
+    options: { updatedBy?: string | null } = {},
+  ): Promise<RoomAdminStateRecord> => {
+    const fields: string[] = [];
+    const values: unknown[] = [roomId];
+    let index = 2;
+
+    if (typeof patch.showGrid === 'boolean') {
+      fields.push(`show_grid = $${index}`);
+      values.push(patch.showGrid);
+      index += 1;
+    }
+    if (typeof patch.showHoverWhenGridHidden === 'boolean') {
+      fields.push(`show_hover_when_grid_hidden = $${index}`);
+      values.push(patch.showHoverWhenGridHidden);
+      index += 1;
+    }
+    if (typeof patch.moveAnimationsEnabled === 'boolean') {
+      fields.push(`move_animations_enabled = $${index}`);
+      values.push(patch.moveAnimationsEnabled);
+      index += 1;
+    }
+    if (typeof patch.latencyTraceEnabled === 'boolean') {
+      fields.push(`latency_trace_enabled = $${index}`);
+      values.push(patch.latencyTraceEnabled);
+      index += 1;
+    }
+    if (typeof patch.lockTilesEnabled === 'boolean') {
+      fields.push(`lock_tiles_enabled = $${index}`);
+      values.push(patch.lockTilesEnabled);
+      index += 1;
+    }
+    if (typeof patch.noPickupEnabled === 'boolean') {
+      fields.push(`no_pickup_enabled = $${index}`);
+      values.push(patch.noPickupEnabled);
+      index += 1;
+    }
+
+    if (fields.length === 0) {
+      return getRoomState(roomId);
+    }
+
+    const updatedBy = options.updatedBy ?? null;
+    fields.push(`updated_at = now()`);
+    fields.push(`updated_by = $${index}`);
+    values.push(updatedBy);
+
+    const result = await pool.query<{
+      room_id: string;
+      show_grid: boolean;
+      show_hover_when_grid_hidden: boolean;
+      move_animations_enabled: boolean;
+      latency_trace_enabled: boolean;
+      lock_tiles_enabled: boolean;
+      no_pickup_enabled: boolean;
+      updated_at: Date;
+      updated_by: string | null;
+    }>(
+      `UPDATE room_admin_state
+          SET ${fields.join(', ')}
+        WHERE room_id = $1
+        RETURNING room_id,
+                  show_grid,
+                  show_hover_when_grid_hidden,
+                  move_animations_enabled,
+                  latency_trace_enabled,
+                  lock_tiles_enabled,
+                  no_pickup_enabled,
+                  updated_at,
+                  updated_by`,
+      values,
+    );
+
+    if (result.rowCount === 0) {
+      await ensureRow(roomId);
+      return updateRoomState(roomId, patch, options);
+    }
+
+    return mapRow(result.rows[0]);
+  };
+
+  return {
+    getRoomState,
+    updateRoomState,
+  };
+};
+
+export const toAdminStatePayload = (
+  record: RoomAdminStateRecord,
+): AdminQuickMenuState => ({
+  showGrid: record.showGrid,
+  showHoverWhenGridHidden: record.showHoverWhenGridHidden,
+  moveAnimationsEnabled: record.moveAnimationsEnabled,
+  latencyTraceEnabled: record.latencyTraceEnabled,
+  lockTilesEnabled: record.lockTilesEnabled,
+  noPickupEnabled: record.noPickupEnabled,
+  updatedAt: record.updatedAt.toISOString(),
+  updatedBy: record.updatedBy ?? null,
+});

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -203,6 +203,48 @@ const MIGRATIONS: Migration[] = [
          ON user_chat_preference(updated_at)`
     ],
   },
+  {
+    id: '0006_admin_state',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS room_admin_state (
+        room_id uuid PRIMARY KEY REFERENCES room(id) ON DELETE CASCADE,
+        show_grid boolean NOT NULL DEFAULT true,
+        show_hover_when_grid_hidden boolean NOT NULL DEFAULT true,
+        move_animations_enabled boolean NOT NULL DEFAULT true,
+        latency_trace_enabled boolean NOT NULL DEFAULT false,
+        lock_tiles_enabled boolean NOT NULL DEFAULT false,
+        no_pickup_enabled boolean NOT NULL DEFAULT false,
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        updated_by uuid REFERENCES app_user(id) ON DELETE SET NULL
+      )`,
+      `INSERT INTO room_admin_state (
+          room_id,
+          show_grid,
+          show_hover_when_grid_hidden,
+          move_animations_enabled,
+          latency_trace_enabled,
+          lock_tiles_enabled,
+          no_pickup_enabled
+        ) VALUES (
+          '${DEV_ROOM_ID}',
+          true,
+          true,
+          true,
+          false,
+          false,
+          false
+        )
+        ON CONFLICT (room_id) DO UPDATE SET
+          show_grid = EXCLUDED.show_grid,
+          show_hover_when_grid_hidden = EXCLUDED.show_hover_when_grid_hidden,
+          move_animations_enabled = EXCLUDED.move_animations_enabled,
+          latency_trace_enabled = EXCLUDED.latency_trace_enabled,
+          lock_tiles_enabled = EXCLUDED.lock_tiles_enabled,
+          no_pickup_enabled = EXCLUDED.no_pickup_enabled,
+          updated_at = now(),
+          updated_by = NULL`
+    ],
+  },
 ];
 
 const ensureMigrationTable = async (pool: Pool): Promise<void> => {


### PR DESCRIPTION
## Summary
- add shared admin quick-menu schemas/OpenAPI surface and export them to consumers
- persist room admin state in Postgres, mirror changes via Redis/pubsub, and expose `/admin/rooms/:roomId/state` plus realtime hydration
- update the React client to hydrate `adminState`, call the PATCH helper for each toggle, and surface pending/disabled UI while updating the docs and screenshot

## Testing
- CI=1 pnpm lint
- CI=1 pnpm typecheck
- CI=1 pnpm test *(fails: Testcontainers cannot find a container runtime; run with BITBY_TEST_STACK=external when Postgres/Redis are available)*

------
https://chatgpt.com/codex/tasks/task_e_68d5354ba9dc8333bac16f4eb2b86653