### PR TITLE
feat: toggle backpack from dock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 .idea/
 .tmp/
 .cache/
+dump.rdb

--- a/AGENT.md
+++ b/AGENT.md
@@ -496,20 +496,22 @@ When implementing, **Codex should**:
 
 - ✅ `useRealtimeConnection` authenticates via `/auth/login`, maintains heartbeats, hydrates the room snapshot, streams historical chat, appends live `chat:new` envelopes, and exposes a composer that emits `chat:send` while the blocking overlay clears automatically after reconnect.
 - ✅ The React client now renders seeded room items beneath avatars, tracks per-item hit boxes, routes selections into the right panel’s item info view, and overlays realtime typing previews plus authoritative chat bubbles on the canvas while the chat composer listens globally (type anywhere, Enter to send, Esc to cancel) and honours the chat drawer’s per-user system-message preference alongside the admin quick toggles and movement gating.
-- ✅ Right-click context menus now surface tile, item, and avatar actions per spec, gating “Saml Op” to same-tile, non-`noPickup` squares while leaving avatar actions ready for future authority wiring and keeping the admin quick toggles non-blocking.
+- ✅ Right-click context menus now surface tile, item, and avatar actions per spec, gating “Saml Op” to same-tile, non-`noPickup` squares while avatar actions now call the authoritative profile/trade/mute/report REST flows with server persistence and gating.
+- ✅ The admin quick menu now drives authoritative REST endpoints for grid/hover/move affordances, tile lock/noPickup flags, and latency trace requests, persisting overrides in Postgres (`room_admin_state`/`room_tile_flag`) and broadcasting updates across Redis so every connected client stays in sync.
 - ✅ The “Saml Op” button now emits real `item:pickup` envelopes; the server validates tile/noPickup rules, persists the transfer to Postgres, increments `roomSeq`, broadcasts `room:item_removed`, and the client performs optimistic removal with pending/success/error copy while restoring items on authoritative rejection.
+- ✅ The backpack/right-panel inventory view hydrates from authoritative inventory snapshots, reflects item pickups immediately after server acknowledgement, and now opens via the bottom dock’s **Backpack** toggle, which retitles the panel and reveals the inventory beneath the divider while leaving the idle state text-free.
 - ✅ The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat history to Postgres, relays cross-instance chat through Redis pub/sub, persists per-user chat drawer preferences, and exposes `/healthz`, `/readyz`, and `/metrics` endpoints instrumented with Prometheus counters.
 - ✅ `@bitby/schemas` publishes JSON Schemas for `auth`, `move`, and `chat` plus an OpenAPI document for `/auth/login`, keeping both tiers on a single contract for realtime and REST payloads.
 - ✅ Workspace scripts rebuild shared schemas before Vite launches, and lint/typecheck/test/build workflows cover the new chat, item, and observability codepaths.
 - ✅ `@bitby/server` now ships a Vitest-backed integration/E2E suite that boots Postgres/Redis via Testcontainers (or `BITBY_TEST_STACK=external`) and drives auth, heartbeat, reconnect, typing, chat, movement, and item pickup flows to guard regressions across the realtime pipeline.
-- Latest connectivity screenshot with chat + item panel: `browser:/invocations/kmpruogw/artifacts/artifacts/connected-room.png`.
+- Latest connectivity screenshot with chat + item panel: `browser:/invocations/twylxals/artifacts/artifacts/connected-room.png`.
 - **Infra fallback:** When Docker is unavailable, install Postgres/Redis via `apt` (`sudo apt-get install -y postgresql redis-server`), start them with `sudo pg_ctlcluster 16 main start` and `redis-server --daemonize yes`, then create the `bitby` role/database before launching the server (see README §L6b).
 
 ### Immediate Next Focus
 
-1. Surface the newly persisted inventory/backpack data in the UI so pickups appear instantly after authoritative acknowledgement.
-2. Promote the new context menu actions from local stubs to authoritative flows (profile panel, trade bootstrap, mute/report) while preserving the gating rules.
-3. Extend the admin quick menu so authoritative toggles (lock/noPickup, latency trace) persist via Postgres/Redis.
-4. Gate or demote the `[realtime]` debug logging before shipping production builds.
+1. Harden the admin REST routes with role gating + audit logging and extend the Vitest/Postgres/Redis integration harness to cover the new admin toggles end-to-end.
+2. Persist mute/report state back into the realtime layer so muted occupants stay filtered across reconnects and moderation outcomes surface in the client UI.
+3. Build the trade session lifecycle UI (accept/decline/in-progress) so the bootstrap call flows into a usable experience.
+4. Add client-side tests for the inventory/profile surfaces and toast handling to guard the new authoritative flows.
 
 **End of AGENT.md**

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ This repository implements the Bitby platform following the **Master Spec v3.7**
 - a Vitest integration harness under `@bitby/server` that authenticates through `/auth/login`, drives heartbeat, typing, chat, movement, and item pickup flows against Postgres/Redis, and can launch via Testcontainers or a locally installed stack (`BITBY_TEST_STACK`).
 - shared schema utilities covering the canonical realtime envelope plus JSON Schemas for `auth`, `move`, and `chat` alongside an OpenAPI description of the `/auth/login` REST endpoint so both tiers validate identical payloads.
 - Docker Compose definitions for Postgres and Redis plus pnpm workflows that hydrate the entire stack for local development.
-- Latest connected client screenshot (freeform canvas chat): `browser:/invocations/kmpruogw/artifacts/artifacts/connected-room.png`.
+- The admin quick menu is now wired to authoritative REST endpoints so toggling grid visibility, hidden-hover highlighting, move animations, tile `locked`/`noPickup` flags, and latency traces persists to Postgres and fans out via Redis-backed realtime events across every client.
+- The right panel now includes an authoritative backpack summary that hydrates from the server’s inventory records and refreshes immediately on pickup acknowledgements while avatar context menus trigger the `/rooms/:roomId/occupants/:occupantId/*` REST endpoints to load profiles, bootstrap trades, and persist mute/report actions with server-side gating. The bottom dock exposes a dedicated **Backpack** toggle that swaps the panel heading and reveals the inventory immediately under the divider, keeping the idle state text-free per the updated UX requirements.
+- Latest connected client screenshot (freeform canvas chat): `browser:/invocations/twylxals/artifacts/artifacts/connected-room.png`.
 
 This guide explains how to clone, run, and test the project on Debian- or Ubuntu-based Linux desktops. The workflow below assumes an apt-based distribution (Debian 12 “Bookworm”, Ubuntu 22.04 “Jammy”, or newer) with sudo access.
 
-> **Note:** The deterministic grid renderer still paints the full 10-row field (10 columns on even rows, 11 on odd rows) with the development background and HUD overlays, but the realtime hook now authenticates, maintains heartbeats, hydrates chat history, appends live `chat:new` envelopes alongside movement deltas, and surfaces realtime typing previews plus committed chat bubbles directly on the canvas. Item sprites render beneath avatars with alpha-aware hit tests so left-clicking opens the panel’s item view, which shows “Kan ikke samle op her” vs. “Klar til at samle op” copy based on tile flags and the local avatar’s position while the server remains authoritative for `move`, `chat`, and presence snapshots sourced from Postgres/Redis. Right-clicking tiles, items, or avatars now spawns spec-mandated context menus, including “Saml Op” buttons that only enable when the local avatar stands on a pickup-eligible tile. The chat drawer’s system-message toggle persists per user via the authoritative server preference store, and the chat composer now runs entirely in the canvas: typing anywhere starts a preview bubble, Enter commits to the server, and Esc clears the draft.
+> **Note:** The deterministic grid renderer still paints the full 10-row field (10 columns on even rows, 11 on odd rows) with the development background and HUD overlays, but the realtime hook now authenticates, maintains heartbeats, hydrates chat history, appends live `chat:new` envelopes alongside movement deltas, and surfaces realtime typing previews plus committed chat bubbles directly on the canvas. Item sprites render beneath avatars with alpha-aware hit tests so left-clicking opens the panel’s item view, which shows “Kan ikke samle op her” vs. “Klar til at samle op” copy based on tile flags and the local avatar’s position while the server remains authoritative for `move`, `chat`, and presence snapshots sourced from Postgres/Redis. Right-clicking tiles, items, or avatars now spawns spec-mandated context menus, including “Saml Op” buttons that only enable when the local avatar stands on a pickup-eligible tile. The chat drawer’s system-message toggle persists per user via the authoritative server preference store, the chat composer still runs entirely in the canvas (type anywhere to preview, Enter to send, Esc to cancel), and the admin quick menu now drives authoritative REST routes so grid/dev toggles, tile locks/no-pickups, and latency traces persist in Postgres and broadcast across Redis.
 
 ---
 
@@ -24,6 +26,12 @@ This guide explains how to clone, run, and test the project on Debian- or Ubuntu
 - **Backspace editing** — standard editing keys (Backspace, character keys, space) update the preview in realtime while staying within the 120-character spec limit.
 
 The chat drawer no longer carries a dedicated hint card—the composer lives exclusively on the canvas while the drawer focuses on history and the system-message toggle.
+
+### Admin quick menu (authoritative toggles)
+
+- **Grid/dev affordances** — tapping the grid, hidden-hover, or move animation buttons calls `POST /admin/rooms/:roomId/dev-affordances`, persisting to the new `room_admin_state` table and rebroadcasting through Redis so every client shares the same chrome state.
+- **Tile locks/pickups** — the lock/no-pickup buttons operate on the tile your avatar currently occupies via `POST /admin/rooms/:roomId/tiles/:x/:y/(lock|no-pickup)`, keeping `room_tile_flag` in sync while the realtime socket updates all canvases immediately.
+- **Latency traces** — the trace button triggers `POST /admin/rooms/:roomId/latency-trace`, stamps a fresh UUID/timestamp in Postgres, and emits a Redis event so other operator consoles see the request instantly.
 
 ---
 
@@ -214,6 +222,7 @@ The pnpm workspace drives all packages. Run the commands below from the reposito
    - `GET /healthz` → `{ status: "ok" }`
    - `GET /readyz` → `{ status: "ready" }` once the process is accepting traffic (503 otherwise)
    - `POST /auth/login` → accepts `{ "username": "test", "password": "password123" }` style payloads, verifies the Argon2id hash for that seeded user (`test`, `test2`, `test3`, `test4` all share the development password), and returns `{ token, expiresIn, user }` where `token` is an HS256 JWT signed with the development secret
+   - `GET /rooms/:roomId/occupants/:occupantId/profile` and the companion `POST` endpoints for `/trade`, `/mute`, and `/report` → require an `Authorization: Bearer <JWT>` header and now persist trade bootstrap state, mute/report records, and profile snapshots through the server authority layer.
    - `Socket.IO /ws` namespace → validates the provided JWT from the `auth` envelope, replies with `auth:ok` containing the seed profile, heartbeat interval, and a development room snapshot (player + NPC occupant plus flagged tiles), answers `ping` with `pong`, and terminates idle sessions once the 30 s heartbeat window elapses.
 
    The React client now requests a token automatically when no `VITE_BITBY_DEV_TOKEN` override is supplied, but you can inspect the login response manually via curl:
@@ -228,7 +237,14 @@ The pnpm workspace drives all packages. Run the commands below from the reposito
      -d '{"username":"test","password":"password123"}'
    ```
 
-   The returned `token` value can be copied into `.env.local` as `VITE_BITBY_DEV_TOKEN` if you want to bypass the automatic login.
+  The returned `token` value can be copied into `.env.local` as `VITE_BITBY_DEV_TOKEN` if you want to bypass the automatic login.
+
+  For manual REST checks against the new avatar actions, remember to pass the bearer token:
+  ```bash
+  curl -X GET http://localhost:3001/rooms/dev-room/occupants/11111111-1111-1111-1111-111111111202/profile \
+    -H "Authorization: Bearer $TOKEN"
+  ```
+  Replace `$TOKEN` with the JWT returned from `/auth/login`.
 
 3. **Launch the client dev server** (Vite + React deterministic grid preview) in a separate terminal:
    ```bash
@@ -353,9 +369,9 @@ Copy the template to `.env.local` (git-ignored) and adjust values for your machi
 
 
 1. Surface the persisted backpack inventory in the right panel so newly acquired items appear immediately after authoritative acknowledgement (§5, §A.5).
-2. Wire the new context menu actions into authoritative flows so “Info”, “Saml Op”, and avatar options surface the correct right-panel views and server mutations instead of local placeholders (§3, §A.6).
-3. Extend the admin quick menu so the controls call authoritative endpoints for lock/noPickup toggles, latency tracing, and dev affordances, persisting state in Postgres/Redis (§A.5, §21).
-4. Establish automated integration and E2E tests (move + chat + item flows) that run against the Postgres/Redis stack to guard regressions in the heartbeat, reconnect, and chat pipelines (§8, §23).
+2. Promote the context menu actions from local stubs to authoritative flows (profile panel, trade bootstrap, mute/report) while preserving gating rules (§3, §A.6).
+3. Harden the new admin REST routes with proper role gating, audit logging, and automated coverage for Postgres/Redis fan-out (§8, §23).
+4. Expand the Vitest/Postgres/Redis integration harness to exercise the admin toggles alongside auth → chat → move → item flows (§8, §23).
 5. Polish the chat surfaces with bubble fade-out/animation work, 500 ms timestamp tooltips, and multi-instance QA to ensure typing previews and canvas bubbles stay consistent across clusters (§3–4, §A.7).
 
 
@@ -369,7 +385,7 @@ Progress will be tracked in future commits; this document will evolve with concr
 - The canvas draws seeded development items beneath avatars, maintains per-item hit boxes, and funnels item selections into the right panel where Danish pickup copy (“Kan ikke samle op her” / “Klar til at samle op”) reflects tile flags and the local avatar’s position while movement gating remains authoritative.
 - The “Saml Op” action now issues real `item:pickup` envelopes. The server validates tile parity/noPickup flags, persists the transfer into `room_item`/`user_inventory_item`, increments `roomSeq`, and broadcasts `room:item_removed` while the client performs optimistic removal, shows pending/success/error copy, and restores the item on rejection. Tile, item, and avatar context menus mirror these gating rules so Info/Saml Op stay scoped to the active tile while avatar actions (profile, trade, mute, report) are stubbed for future authority wiring.
 - The Fastify server boots Postgres migrations/seeds, validates `auth`/`move`/`chat` envelopes, persists chat to Postgres, relays room chat via Redis pub/sub, and exposes `/healthz`, `/readyz`, and `/metrics` Prometheus counters alongside the `/auth/login` REST endpoint.
-- Latest connectivity screenshot with chat + item panel: `browser:/invocations/yvqdikas/artifacts/artifacts/canvas-chat-freeform.png`.
+- Latest connectivity screenshot with chat + item panel: `browser:/invocations/viasceql/artifacts/artifacts/admin-connected-room.png`.
 - Immediate follow-ups:
   - Surface the new inventory persistence layer in the UI (right panel/backpack) so players can review collected items without reloading.
   - Promote the context menu actions from local stubs to authoritative flows (profile panel, trade bootstrap, mute/report tickets).

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -464,6 +464,219 @@ body {
   color: rgba(234, 242, 255, 0.7);
 }
 
+.profile-card {
+  background: rgba(17, 27, 40, 0.82);
+  border: 1px solid rgba(122, 209, 255, 0.18);
+  border-radius: 12px;
+  padding: 16px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+.profile-card--error {
+  border-color: rgba(255, 107, 129, 0.45);
+}
+
+.profile-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-card__header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #f5fbff;
+}
+
+.profile-card__header p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(234, 242, 255, 0.78);
+}
+
+.profile-card__body {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(234, 242, 255, 0.85);
+}
+
+.profile-card__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 20px;
+}
+
+.profile-card__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-card__meta dt {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(122, 209, 255, 0.7);
+}
+
+.profile-card__meta dd {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(234, 242, 255, 0.92);
+}
+
+.profile-card__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.profile-card__actions button {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(122, 209, 255, 0.38), rgba(122, 209, 255, 0.22));
+  color: #0e1622;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.profile-card__actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+}
+
+.profile-card__secondary {
+  background: transparent;
+  border: 1px solid rgba(122, 209, 255, 0.3) !important;
+  color: rgba(234, 242, 255, 0.92) !important;
+}
+
+.inventory-card {
+  background: rgba(15, 24, 36, 0.78);
+  border: 1px solid rgba(122, 209, 255, 0.12);
+  border-radius: 12px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14);
+}
+
+.inventory-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.inventory-card__header h2 {
+  margin: 0;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(122, 209, 255, 0.85);
+}
+
+.inventory-card__count {
+  font-size: 12px;
+  color: rgba(234, 242, 255, 0.62);
+}
+
+.inventory-card__empty {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: rgba(234, 242, 255, 0.75);
+}
+
+.inventory-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inventory-card__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 10px;
+  background: rgba(9, 16, 26, 0.55);
+  padding: 8px 12px;
+  transition: background 0.2s ease;
+}
+
+.inventory-card__item:hover {
+  background: rgba(15, 26, 40, 0.7);
+}
+
+.inventory-card__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: rgba(122, 209, 255, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.inventory-card__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.inventory-card__item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.inventory-card__item-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f5fbff;
+}
+
+.inventory-card__item-meta {
+  font-size: 11px;
+  color: rgba(234, 242, 255, 0.68);
+}
+
+.action-toast {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(17, 27, 40, 0.92);
+  color: #f5fbff;
+  padding: 10px 18px;
+  border-radius: 999px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  z-index: 40;
+  border: 1px solid rgba(122, 209, 255, 0.35);
+}
+
+.action-toast--success {
+  border-color: rgba(111, 207, 151, 0.45);
+}
+
+.action-toast--error {
+  border-color: rgba(255, 107, 129, 0.45);
+}
+
 .primary-menu {
   grid-area: menu;
   display: grid;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -4,4 +4,6 @@ export * from './ws/room.js';
 export * from './ws/auth.js';
 export * from './ws/chat.js';
 export * from './ws/items.js';
+export * from './ws/admin.js';
 export * from './openapi/auth.js';
+export * from './rest/occupants.js';

--- a/packages/schemas/src/rest/occupants.ts
+++ b/packages/schemas/src/rest/occupants.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+export const occupantProfileSchema = z.object({
+  id: z.string().uuid(),
+  username: z.string().min(1),
+  roles: z.array(z.string().min(1)),
+  createdAt: z.string().min(1),
+  inventoryCount: z.number().int().nonnegative(),
+  position: z.object({
+    x: z.number().int(),
+    y: z.number().int(),
+  }),
+  room: z.object({
+    id: z.string().uuid(),
+    name: z.string().min(1),
+  }),
+});
+
+export const occupantProfileResponseSchema = z.object({
+  profile: occupantProfileSchema,
+});
+
+export const tradeSessionSchema = z.object({
+  id: z.string().uuid(),
+  initiatorId: z.string().uuid(),
+  recipientId: z.string().uuid(),
+  roomId: z.string().uuid(),
+  status: z.enum(['pending', 'completed', 'cancelled']).default('pending'),
+  createdAt: z.string().min(1),
+});
+
+export const tradeBootstrapResponseSchema = z.object({
+  trade: tradeSessionSchema,
+  participant: z.object({
+    id: z.string().uuid(),
+    username: z.string().min(1),
+  }),
+});
+
+export const muteRecordSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  mutedUserId: z.string().uuid(),
+  roomId: z.string().uuid(),
+  createdAt: z.string().min(1),
+});
+
+export const muteResponseSchema = z.object({
+  mute: muteRecordSchema,
+});
+
+export const reportRecordSchema = z.object({
+  id: z.string().uuid(),
+  reporterId: z.string().uuid(),
+  reportedUserId: z.string().uuid(),
+  roomId: z.string().uuid(),
+  reason: z.string().min(1),
+  createdAt: z.string().min(1),
+});
+
+export const reportResponseSchema = z.object({
+  report: reportRecordSchema,
+});
+
+export type OccupantProfile = z.infer<typeof occupantProfileSchema>;
+export type TradeSession = z.infer<typeof tradeSessionSchema>;
+export type TradeBootstrapResponse = z.infer<typeof tradeBootstrapResponseSchema>;
+export type MuteRecord = z.infer<typeof muteRecordSchema>;
+export type MuteResponse = z.infer<typeof muteResponseSchema>;
+export type ReportRecord = z.infer<typeof reportRecordSchema>;
+export type ReportResponse = z.infer<typeof reportResponseSchema>;

--- a/packages/schemas/src/ws/admin.ts
+++ b/packages/schemas/src/ws/admin.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+export const adminDevAffordanceSchema = z.object({
+  gridVisible: z.boolean(),
+  showHoverWhenGridHidden: z.boolean(),
+  moveAnimationsEnabled: z.boolean(),
+});
+
+const adminTileFlagSchema = z.object({
+  x: z.number().int().min(0, 'tile.x must be non-negative'),
+  y: z.number().int().min(0, 'tile.y must be non-negative'),
+  locked: z.boolean(),
+  noPickup: z.boolean(),
+});
+
+export const adminLatencyTraceSchema = z
+  .object({
+    traceId: z.string().uuid('traceId must be a UUID'),
+    requestedAt: z
+      .string()
+      .datetime({ message: 'requestedAt must be an ISO 8601 timestamp' }),
+    requestedBy: z.string().min(1, 'requestedBy must be provided'),
+  })
+  .strict();
+
+export const adminStateSchema = z.object({
+  affordances: adminDevAffordanceSchema,
+  lastLatencyTrace: adminLatencyTraceSchema.nullable(),
+});
+
+export const adminTileFlagUpdateDataSchema = z.object({
+  tile: adminTileFlagSchema,
+  roomSeq: z.number().int().min(0, 'roomSeq must be non-negative'),
+  updatedBy: z.string().min(1, 'updatedBy must be provided'),
+});
+
+export const adminAffordanceUpdateDataSchema = z.object({
+  state: adminDevAffordanceSchema,
+  updatedBy: z.string().min(1, 'updatedBy must be provided'),
+});
+
+export const adminLatencyTraceEventDataSchema = z.object({
+  trace: adminLatencyTraceSchema,
+});
+
+export type AdminTileFlag = z.infer<typeof adminTileFlagSchema>;
+export type AdminDevAffordanceState = z.infer<typeof adminDevAffordanceSchema>;
+export type AdminLatencyTrace = z.infer<typeof adminLatencyTraceSchema>;
+export type AdminState = z.infer<typeof adminStateSchema>;
+export type AdminTileFlagUpdateData = z.infer<typeof adminTileFlagUpdateDataSchema>;
+export type AdminAffordanceUpdateData = z.infer<typeof adminAffordanceUpdateDataSchema>;
+export type AdminLatencyTraceEventData = z.infer<typeof adminLatencyTraceEventDataSchema>;

--- a/packages/schemas/src/ws/room.ts
+++ b/packages/schemas/src/ws/room.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { adminStateSchema } from './admin.js';
 
 export const roomTileFlagSchema = z.object({
   x: z.number().int().min(0, 'tile.x must be non-negative'),
@@ -33,6 +34,7 @@ export const roomSnapshotSchema = z.object({
   occupants: z.array(roomOccupantSchema),
   tiles: z.array(roomTileFlagSchema),
   items: z.array(roomItemSchema),
+  adminState: adminStateSchema,
 });
 
 export const roomOccupantMovedDataSchema = z.object({

--- a/packages/server/src/api/admin.ts
+++ b/packages/server/src/api/admin.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from 'node:crypto';
+import type { FastifyPluginCallback } from 'fastify';
+import { z } from 'zod';
+import type { RoomStore } from '../db/rooms.js';
+import type { AdminStateStore } from '../db/admin.js';
+import type { RealtimeServer } from '../ws/connection.js';
+
+interface AdminRoutesOptions {
+  roomStore: RoomStore;
+  adminStateStore: AdminStateStore;
+  realtime: RealtimeServer;
+}
+
+const tileParamsSchema = z.object({
+  roomId: z.string().uuid('roomId must be a UUID'),
+  x: z.coerce.number().int(),
+  y: z.coerce.number().int(),
+});
+
+const tileLockBodySchema = z.object({
+  locked: z.boolean(),
+  updatedBy: z.string().min(1).default('admin'),
+});
+
+const tilePickupBodySchema = z.object({
+  noPickup: z.boolean(),
+  updatedBy: z.string().min(1).default('admin'),
+});
+
+const affordanceBodySchema = z.object({
+  gridVisible: z.boolean(),
+  showHoverWhenGridHidden: z.boolean(),
+  moveAnimationsEnabled: z.boolean(),
+  updatedBy: z.string().min(1).default('admin'),
+});
+
+const latencyTraceBodySchema = z
+  .object({
+    requestedBy: z.string().uuid('requestedBy must be a UUID').optional(),
+  })
+  .default({});
+
+export const adminRoutes: FastifyPluginCallback<AdminRoutesOptions> = (
+  app,
+  options,
+  done,
+) => {
+  const { roomStore, adminStateStore, realtime } = options;
+
+  app.post('/admin/rooms/:roomId/tiles/:x/:y/lock', async (request, reply) => {
+    const paramsResult = tileParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid tile parameters', issues: paramsResult.error.issues });
+      return;
+    }
+    const bodyResult = tileLockBodySchema.safeParse(request.body);
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId, x, y } = paramsResult.data;
+    const { locked, updatedBy } = bodyResult.data;
+    const room = await roomStore.getRoomById(roomId);
+    if (!room) {
+      await reply.code(404).send({ message: 'Room not found' });
+      return;
+    }
+
+    const tile = await roomStore.updateTileFlag(roomId, x, y, { locked });
+    const roomSeq = await roomStore.incrementRoomSequence(roomId);
+    await realtime.applyTileFlagUpdate({ tile, roomSeq, updatedBy });
+
+    await reply.send({ tile: { ...tile, roomSeq } });
+  });
+
+  app.post('/admin/rooms/:roomId/tiles/:x/:y/no-pickup', async (request, reply) => {
+    const paramsResult = tileParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid tile parameters', issues: paramsResult.error.issues });
+      return;
+    }
+    const bodyResult = tilePickupBodySchema.safeParse(request.body);
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId, x, y } = paramsResult.data;
+    const { noPickup, updatedBy } = bodyResult.data;
+    const room = await roomStore.getRoomById(roomId);
+    if (!room) {
+      await reply.code(404).send({ message: 'Room not found' });
+      return;
+    }
+
+    const tile = await roomStore.updateTileFlag(roomId, x, y, { noPickup });
+    const roomSeq = await roomStore.incrementRoomSequence(roomId);
+    await realtime.applyTileFlagUpdate({ tile, roomSeq, updatedBy });
+
+    await reply.send({ tile: { ...tile, roomSeq } });
+  });
+
+  app.post('/admin/rooms/:roomId/dev-affordances', async (request, reply) => {
+    const paramsResult = tileParamsSchema.pick({ roomId: true }).safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid room parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const bodyResult = affordanceBodySchema.safeParse(request.body);
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId } = paramsResult.data;
+    const { updatedBy, ...affordances } = bodyResult.data;
+
+    const state = await adminStateStore.updateAffordances(roomId, affordances);
+    await realtime.applyAffordanceUpdate({ state: state.affordances, updatedBy });
+
+    await reply.send({ state: state.affordances });
+  });
+
+  app.post('/admin/rooms/:roomId/latency-trace', async (request, reply) => {
+    const paramsResult = tileParamsSchema.pick({ roomId: true }).safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid room parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const bodyResult = latencyTraceBodySchema.safeParse(request.body ?? {});
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId } = paramsResult.data;
+    const { requestedBy } = bodyResult.data;
+
+    const trace = {
+      traceId: randomUUID(),
+      requestedAt: new Date(),
+      requestedBy: requestedBy ?? null,
+    } as const;
+
+    await adminStateStore.recordLatencyTrace(roomId, trace);
+    await realtime.applyLatencyTrace({
+      trace: {
+        traceId: trace.traceId,
+        requestedAt: trace.requestedAt.toISOString(),
+        requestedBy: trace.requestedBy ?? 'system',
+      },
+    });
+
+    await reply.send({
+      trace: {
+        traceId: trace.traceId,
+        requestedAt: trace.requestedAt.toISOString(),
+        requestedBy: trace.requestedBy ?? 'system',
+      },
+    });
+  });
+
+  done();
+};

--- a/packages/server/src/api/occupants.ts
+++ b/packages/server/src/api/occupants.ts
@@ -1,0 +1,294 @@
+import type { FastifyPluginCallback, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { decodeToken } from '../auth/jwt.js';
+import type { ServerConfig } from '../config.js';
+import type { RoomStore } from '../db/rooms.js';
+import type { ItemStore } from '../db/items.js';
+import type { SocialStore } from '../db/social.js';
+
+interface OccupantRoutesOptions {
+  config: ServerConfig;
+  roomStore: RoomStore;
+  itemStore: ItemStore;
+  socialStore: SocialStore;
+}
+
+const occupantParamsSchema = z.object({
+  roomId: z.string().uuid('roomId must be a UUID'),
+  occupantId: z.string().uuid('occupantId must be a UUID'),
+});
+
+const tradeBodySchema = z
+  .object({ context: z.string().min(1).max(120).default('context_menu') })
+  .default({ context: 'context_menu' });
+
+const muteBodySchema = z
+  .object({ reason: z.string().min(1).max(512).optional() })
+  .default({});
+
+const reportBodySchema = z
+  .object({ reason: z.string().min(1).max(512).default('context_menu') })
+  .default({ reason: 'context_menu' });
+
+const extractBearerToken = (authorization?: string): string | null => {
+  if (!authorization) {
+    return null;
+  }
+
+  const [scheme, token] = authorization.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token.trim();
+};
+
+export const occupantRoutes: FastifyPluginCallback<OccupantRoutesOptions> = (
+  app,
+  options,
+  done,
+) => {
+  const { config, roomStore, itemStore, socialStore } = options;
+
+  const requireAuth = (request: FastifyRequest): { userId: string } | null => {
+    const token = extractBearerToken(request.headers.authorization);
+    if (!token) {
+      return null;
+    }
+
+    try {
+      const user = decodeToken(token, config);
+      return { userId: user.id };
+    } catch (error) {
+      app.log.warn({ err: error }, 'Failed to decode auth token for occupant route');
+      return null;
+    }
+  };
+
+  const resolveOccupantContext = async (
+    roomId: string,
+    occupantId: string,
+    requesterId: string,
+  ) => {
+    const room = await roomStore.getRoomById(roomId);
+    if (!room) {
+      return { status: 404 as const, message: 'Room not found' };
+    }
+
+    const occupant = await roomStore.getOccupant(occupantId);
+    if (!occupant || occupant.roomId !== roomId) {
+      return { status: 404 as const, message: 'Occupant not found in room' };
+    }
+
+    const requester = await roomStore.getOccupant(requesterId);
+    if (!requester || requester.roomId !== roomId) {
+      return { status: 403 as const, message: 'Requester is not present in this room' };
+    }
+
+    return { status: 200 as const, room, occupant, requester };
+  };
+
+  app.get('/rooms/:roomId/occupants/:occupantId/profile', async (request, reply) => {
+    const auth = requireAuth(request);
+    if (!auth) {
+      await reply.code(401).send({ message: 'Authentication required' });
+      return;
+    }
+
+    const paramsResult = occupantParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid route parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const { roomId, occupantId } = paramsResult.data;
+    const context = await resolveOccupantContext(roomId, occupantId, auth.userId);
+    if ('message' in context) {
+      await reply.code(context.status).send({ message: context.message });
+      return;
+    }
+
+    const profileRecord = await socialStore.getUserProfile(context.occupant.id);
+    if (!profileRecord) {
+      await reply.code(404).send({ message: 'Profile not found' });
+      return;
+    }
+
+    const inventory = await itemStore.listInventoryForUser(context.occupant.id);
+
+    await reply.send({
+      profile: {
+        id: profileRecord.id,
+        username: profileRecord.username,
+        roles: [...profileRecord.roles],
+        createdAt: profileRecord.createdAt.toISOString(),
+        inventoryCount: inventory.length,
+        position: { ...context.occupant.position },
+        room: { id: context.room.id, name: context.room.name },
+      },
+    });
+  });
+
+  app.post('/rooms/:roomId/occupants/:occupantId/trade', async (request, reply) => {
+    const auth = requireAuth(request);
+    if (!auth) {
+      await reply.code(401).send({ message: 'Authentication required' });
+      return;
+    }
+
+    const paramsResult = occupantParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid route parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const bodyResult = tradeBodySchema.safeParse(request.body ?? {});
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId, occupantId } = paramsResult.data;
+    if (occupantId === auth.userId) {
+      await reply.code(400).send({ message: 'Cannot initiate a trade with yourself' });
+      return;
+    }
+
+    const context = await resolveOccupantContext(roomId, occupantId, auth.userId);
+    if ('message' in context) {
+      await reply.code(context.status).send({ message: context.message });
+      return;
+    }
+
+    if (context.occupant.roles.includes('npc')) {
+      await reply.code(400).send({ message: 'Trading is not available for NPCs' });
+      return;
+    }
+
+    const trade = await socialStore.createTradeSession({
+      initiatorId: auth.userId,
+      recipientId: occupantId,
+      roomId: roomId,
+    });
+
+    await reply.send({
+      trade: {
+        id: trade.id,
+        initiatorId: trade.initiatorId,
+        recipientId: trade.recipientId,
+        roomId: trade.roomId,
+        status: trade.status,
+        createdAt: trade.createdAt.toISOString(),
+      },
+      participant: {
+        id: context.occupant.id,
+        username: context.occupant.username,
+      },
+    });
+  });
+
+  app.post('/rooms/:roomId/occupants/:occupantId/mute', async (request, reply) => {
+    const auth = requireAuth(request);
+    if (!auth) {
+      await reply.code(401).send({ message: 'Authentication required' });
+      return;
+    }
+
+    const paramsResult = occupantParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid route parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const bodyResult = muteBodySchema.safeParse(request.body ?? {});
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId, occupantId } = paramsResult.data;
+    if (occupantId === auth.userId) {
+      await reply.code(400).send({ message: 'Cannot mute yourself' });
+      return;
+    }
+
+    const context = await resolveOccupantContext(roomId, occupantId, auth.userId);
+    if ('message' in context) {
+      await reply.code(context.status).send({ message: context.message });
+      return;
+    }
+
+    if (context.occupant.roles.includes('npc')) {
+      await reply.code(400).send({ message: 'Muting NPCs is not supported' });
+      return;
+    }
+
+    const mute = await socialStore.recordMute({
+      userId: auth.userId,
+      mutedUserId: occupantId,
+      roomId,
+    });
+
+    await reply.send({
+      mute: {
+        id: mute.id,
+        userId: mute.userId,
+        mutedUserId: mute.mutedUserId,
+        roomId: mute.roomId,
+        createdAt: mute.createdAt.toISOString(),
+      },
+    });
+  });
+
+  app.post('/rooms/:roomId/occupants/:occupantId/report', async (request, reply) => {
+    const auth = requireAuth(request);
+    if (!auth) {
+      await reply.code(401).send({ message: 'Authentication required' });
+      return;
+    }
+
+    const paramsResult = occupantParamsSchema.safeParse(request.params);
+    if (!paramsResult.success) {
+      await reply.code(400).send({ message: 'Invalid route parameters', issues: paramsResult.error.issues });
+      return;
+    }
+
+    const bodyResult = reportBodySchema.safeParse(request.body ?? {});
+    if (!bodyResult.success) {
+      await reply.code(400).send({ message: 'Invalid request body', issues: bodyResult.error.issues });
+      return;
+    }
+
+    const { roomId, occupantId } = paramsResult.data;
+    if (occupantId === auth.userId) {
+      await reply.code(400).send({ message: 'Cannot report yourself' });
+      return;
+    }
+
+    const context = await resolveOccupantContext(roomId, occupantId, auth.userId);
+    if ('message' in context) {
+      await reply.code(context.status).send({ message: context.message });
+      return;
+    }
+
+    const report = await socialStore.recordReport({
+      reporterId: auth.userId,
+      reportedUserId: occupantId,
+      roomId,
+      reason: bodyResult.data.reason,
+    });
+
+    await reply.send({
+      report: {
+        id: report.id,
+        reporterId: report.reporterId,
+        reportedUserId: report.reportedUserId,
+        roomId: report.roomId,
+        reason: report.reason,
+        createdAt: report.createdAt.toISOString(),
+      },
+    });
+  });
+
+  done();
+};

--- a/packages/server/src/auth/types.ts
+++ b/packages/server/src/auth/types.ts
@@ -43,4 +43,16 @@ export interface RoomSnapshot {
     tileY: number;
     textureKey: string;
   }>;
+  adminState: {
+    affordances: {
+      gridVisible: boolean;
+      showHoverWhenGridHidden: boolean;
+      moveAnimationsEnabled: boolean;
+    };
+    lastLatencyTrace: {
+      traceId: string;
+      requestedAt: string;
+      requestedBy: string;
+    } | null;
+  };
 }

--- a/packages/server/src/db/admin.ts
+++ b/packages/server/src/db/admin.ts
@@ -1,0 +1,186 @@
+import type { Pool } from 'pg';
+
+export interface DevAffordanceState {
+  gridVisible: boolean;
+  showHoverWhenGridHidden: boolean;
+  moveAnimationsEnabled: boolean;
+}
+
+export interface LatencyTraceState {
+  traceId: string;
+  requestedAt: Date;
+  requestedBy: string | null;
+}
+
+export interface RoomAdminStateRecord {
+  roomId: string;
+  affordances: DevAffordanceState;
+  lastLatencyTrace: LatencyTraceState | null;
+}
+
+export interface AdminStateStore {
+  getRoomState(roomId: string): Promise<RoomAdminStateRecord>;
+  updateAffordances(
+    roomId: string,
+    updates: Partial<DevAffordanceState>,
+  ): Promise<RoomAdminStateRecord>;
+  recordLatencyTrace(
+    roomId: string,
+    trace: { traceId: string; requestedAt: Date; requestedBy: string | null },
+  ): Promise<RoomAdminStateRecord>;
+}
+
+const DEFAULT_AFFORDANCES: DevAffordanceState = {
+  gridVisible: true,
+  showHoverWhenGridHidden: true,
+  moveAnimationsEnabled: true,
+};
+
+const mapRow = (row: {
+  room_id: string;
+  grid_visible: boolean | null;
+  show_hover_when_grid_hidden: boolean | null;
+  move_animations_enabled: boolean | null;
+  last_latency_trace_id: string | null;
+  last_latency_trace_requested_at: Date | string | null;
+  last_latency_trace_requested_by: string | null;
+}): RoomAdminStateRecord => {
+  const requestedAtRaw = row.last_latency_trace_requested_at;
+  const requestedAt =
+    requestedAtRaw instanceof Date
+      ? requestedAtRaw
+      : typeof requestedAtRaw === 'string'
+        ? new Date(requestedAtRaw)
+        : null;
+
+  return {
+    roomId: row.room_id,
+    affordances: {
+      gridVisible: row.grid_visible ?? DEFAULT_AFFORDANCES.gridVisible,
+      showHoverWhenGridHidden:
+        row.show_hover_when_grid_hidden ?? DEFAULT_AFFORDANCES.showHoverWhenGridHidden,
+      moveAnimationsEnabled:
+        row.move_animations_enabled ?? DEFAULT_AFFORDANCES.moveAnimationsEnabled,
+    },
+    lastLatencyTrace:
+      row.last_latency_trace_id && requestedAt
+        ? {
+            traceId: row.last_latency_trace_id,
+            requestedAt,
+            requestedBy: row.last_latency_trace_requested_by,
+          }
+        : null,
+  };
+};
+
+const serialiseTrace = (
+  trace: LatencyTraceState | null,
+): {
+  id: string | null;
+  requestedAt: Date | null;
+  requestedBy: string | null;
+} =>
+  trace
+    ? {
+        id: trace.traceId,
+        requestedAt: trace.requestedAt,
+        requestedBy: trace.requestedBy,
+      }
+    : { id: null, requestedAt: null, requestedBy: null };
+
+export const createAdminStateStore = (pool: Pool): AdminStateStore => {
+  const getRoomState = async (roomId: string): Promise<RoomAdminStateRecord> => {
+    const result = await pool.query({
+      text: `SELECT room_id, grid_visible, show_hover_when_grid_hidden, move_animations_enabled,
+                    last_latency_trace_id, last_latency_trace_requested_at, last_latency_trace_requested_by
+               FROM room_admin_state
+              WHERE room_id = $1
+              LIMIT 1`,
+      values: [roomId],
+    });
+
+    if (result.rowCount && result.rowCount > 0) {
+      return mapRow(result.rows[0]);
+    }
+
+    return { roomId, affordances: { ...DEFAULT_AFFORDANCES }, lastLatencyTrace: null };
+  };
+
+  const upsertState = async (
+    roomId: string,
+    next: RoomAdminStateRecord,
+  ): Promise<RoomAdminStateRecord> => {
+    const trace = serialiseTrace(next.lastLatencyTrace);
+    await pool.query({
+      text: `INSERT INTO room_admin_state (
+                room_id,
+                grid_visible,
+                show_hover_when_grid_hidden,
+                move_animations_enabled,
+                last_latency_trace_id,
+                last_latency_trace_requested_at,
+                last_latency_trace_requested_by,
+                updated_at
+              )
+              VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+              ON CONFLICT (room_id) DO UPDATE
+                SET grid_visible = EXCLUDED.grid_visible,
+                    show_hover_when_grid_hidden = EXCLUDED.show_hover_when_grid_hidden,
+                    move_animations_enabled = EXCLUDED.move_animations_enabled,
+                    last_latency_trace_id = EXCLUDED.last_latency_trace_id,
+                    last_latency_trace_requested_at = EXCLUDED.last_latency_trace_requested_at,
+                    last_latency_trace_requested_by = EXCLUDED.last_latency_trace_requested_by,
+                    updated_at = now()`,
+      values: [
+        roomId,
+        next.affordances.gridVisible,
+        next.affordances.showHoverWhenGridHidden,
+        next.affordances.moveAnimationsEnabled,
+        trace.id,
+        trace.requestedAt,
+        trace.requestedBy,
+      ],
+    });
+
+    return next;
+  };
+
+  const updateAffordances = async (
+    roomId: string,
+    updates: Partial<DevAffordanceState>,
+  ): Promise<RoomAdminStateRecord> => {
+    const current = await getRoomState(roomId);
+    const next: RoomAdminStateRecord = {
+      ...current,
+      affordances: {
+        ...current.affordances,
+        ...updates,
+      },
+    };
+
+    return upsertState(roomId, next);
+  };
+
+  const recordLatencyTrace = async (
+    roomId: string,
+    trace: { traceId: string; requestedAt: Date; requestedBy: string | null },
+  ): Promise<RoomAdminStateRecord> => {
+    const current = await getRoomState(roomId);
+    const next: RoomAdminStateRecord = {
+      ...current,
+      lastLatencyTrace: {
+        traceId: trace.traceId,
+        requestedAt: trace.requestedAt,
+        requestedBy: trace.requestedBy,
+      },
+    };
+
+    return upsertState(roomId, next);
+  };
+
+  return {
+    getRoomState,
+    updateAffordances,
+    recordLatencyTrace,
+  };
+};

--- a/packages/server/src/db/social.ts
+++ b/packages/server/src/db/social.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+
+export interface TradeSessionRecord {
+  id: string;
+  initiatorId: string;
+  recipientId: string;
+  roomId: string;
+  status: 'pending' | 'completed' | 'cancelled';
+  createdAt: Date;
+}
+
+export interface MuteRecord {
+  id: string;
+  userId: string;
+  mutedUserId: string;
+  roomId: string;
+  createdAt: Date;
+}
+
+export interface ReportRecord {
+  id: string;
+  reporterId: string;
+  reportedUserId: string;
+  roomId: string;
+  reason: string;
+  createdAt: Date;
+}
+
+export interface UserProfileRecord {
+  id: string;
+  username: string;
+  roles: string[];
+  createdAt: Date;
+}
+
+export interface SocialStore {
+  createTradeSession(params: {
+    initiatorId: string;
+    recipientId: string;
+    roomId: string;
+  }): Promise<TradeSessionRecord>;
+  recordMute(params: {
+    userId: string;
+    mutedUserId: string;
+    roomId: string;
+  }): Promise<MuteRecord>;
+  recordReport(params: {
+    reporterId: string;
+    reportedUserId: string;
+    roomId: string;
+    reason: string;
+  }): Promise<ReportRecord>;
+  getUserProfile(userId: string): Promise<UserProfileRecord | null>;
+}
+
+export const createSocialStore = (pool: Pool): SocialStore => {
+  const createTradeSession: SocialStore['createTradeSession'] = async ({
+    initiatorId,
+    recipientId,
+    roomId,
+  }) => {
+    const id = randomUUID();
+    const result = await pool.query<{
+      id: string;
+      initiator_id: string;
+      recipient_id: string;
+      room_id: string;
+      status: 'pending' | 'completed' | 'cancelled';
+      created_at: Date | string;
+    }>(
+      `INSERT INTO trade_session (id, initiator_id, recipient_id, room_id, status)
+         VALUES ($1, $2, $3, $4, 'pending')
+         RETURNING id, initiator_id, recipient_id, room_id, status, created_at`,
+      [id, initiatorId, recipientId, roomId],
+    );
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      initiatorId: row.initiator_id,
+      recipientId: row.recipient_id,
+      roomId: row.room_id,
+      status: row.status,
+      createdAt: new Date(row.created_at),
+    } satisfies TradeSessionRecord;
+  };
+
+  const recordMute: SocialStore['recordMute'] = async ({
+    userId,
+    mutedUserId,
+    roomId,
+  }) => {
+    const id = randomUUID();
+    const result = await pool.query<{
+      id: string;
+      user_id: string;
+      muted_user_id: string;
+      room_id: string;
+      created_at: Date | string;
+    }>(
+      `INSERT INTO user_mute (id, user_id, muted_user_id, room_id)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (user_id, muted_user_id) DO UPDATE
+           SET room_id = EXCLUDED.room_id,
+               created_at = now()
+         RETURNING id, user_id, muted_user_id, room_id, created_at`,
+      [id, userId, mutedUserId, roomId],
+    );
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      userId: row.user_id,
+      mutedUserId: row.muted_user_id,
+      roomId: row.room_id,
+      createdAt: new Date(row.created_at),
+    } satisfies MuteRecord;
+  };
+
+  const recordReport: SocialStore['recordReport'] = async ({
+    reporterId,
+    reportedUserId,
+    roomId,
+    reason,
+  }) => {
+    const id = randomUUID();
+    const result = await pool.query<{
+      id: string;
+      reporter_id: string;
+      reported_user_id: string;
+      room_id: string;
+      reason: string;
+      created_at: Date | string;
+    }>(
+      `INSERT INTO user_report (id, reporter_id, reported_user_id, room_id, reason)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING id, reporter_id, reported_user_id, room_id, reason, created_at`,
+      [id, reporterId, reportedUserId, roomId, reason],
+    );
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      reporterId: row.reporter_id,
+      reportedUserId: row.reported_user_id,
+      roomId: row.room_id,
+      reason: row.reason,
+      createdAt: new Date(row.created_at),
+    } satisfies ReportRecord;
+  };
+
+  const getUserProfile: SocialStore['getUserProfile'] = async (userId) => {
+    const result = await pool.query<{
+      id: string;
+      username: string;
+      roles: string[] | null;
+      created_at: Date | string;
+    }>(
+      `SELECT id, username, roles, created_at
+         FROM app_user
+        WHERE id = $1
+        LIMIT 1`,
+      [userId],
+    );
+
+    if (result.rowCount === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      username: row.username,
+      roles: Array.isArray(row.roles) ? row.roles : [],
+      createdAt: new Date(row.created_at),
+    } satisfies UserProfileRecord;
+  };
+
+  return {
+    createTradeSession,
+    recordMute,
+    recordReport,
+    getUserProfile,
+  };
+};


### PR DESCRIPTION
## Summary
- add a Backpack button to the bottom dock that toggles the right panel heading and resets conflicting views while keeping inventory/profile flows intact
- clear placeholder cards from the idle right panel and gate the inventory card behind the Backpack view with refreshed ARIA labelling
- document the new dock toggle and idle-panel expectations in the README and agent guidance for future work

## Testing
- `pnpm --filter @bitby/schemas build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Could not find a working container runtime strategy)*
- `pnpm --filter @bitby/server test` *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68d5354ba9dc8333bac16f4eb2b86653