### PR TITLE
chore(atlas): bootstrap codemap + CI (no auto commits)

### DIFF
--- a/.codemaprc.json
+++ b/.codemaprc.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    "packages/**/*.{ts,tsx,js,jsx}"
+  ],
+  "exclude": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/.next/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/*.d.ts",
+    "**/*.test.*",
+    "**/*.spec.*"
+  ],
+  "markdownMaxPerGroup": 200
+}

--- a/AGENT.md
+++ b/AGENT.md
@@ -510,4 +510,12 @@ When implementing, **Codex should**:
 1. Persist and expose historical trade summaries (participants, timestamps, exchanged items) so reconnects and profile views can reference prior sessions without re-querying adhoc state.
 2. Extend chat retention beyond the hot 200-message ring buffer by introducing time-based archival/expiry so Postgres stays lean while compliance exports remain possible.
 
+---
+
+## Code Atlas Contract
+
+- Always read `codemap.json` first to locate files for a task by `@module`, `@tags`, or exports.
+- When you create or edit a file, add or update the `@module` and `@tags` header.
+- After edits, run `pnpm codemap` and commit the refreshed map together with your code.
+
 **End of AGENT.md**

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,0 +1,177 @@
+# CODEMAP
+
+Generated at: 2025-09-26T21:01:08.130Z
+
+## Module: Uncategorized
+
+- **packages/client/src/App.tsx**
+  - Exports: default
+  - Imports: ./assets/items/couch.png, ./assets/items/plant.png, ./canvas/GridCanvas, ./canvas/geometry, ./canvas/types, ./components/InventoryCard, ./components/ProfilePanel, ./hooks/useActionToast, ./styles.css, ./ws/useRealtimeConnection, react
+  - Functions:
+    - adjustPosition (line 164)
+      - const adjustPosition = (): void =>
+    - renderTileSection (line 248)
+      - const renderTileSection = (tile: GridTile, items: CanvasItem[], focusedItemId: string | null): JSX.Element =>
+    - renderTileMenu (line 311)
+      - const renderTileMenu = (payload: TileContextMenuState): JSX.Element =>
+    - renderOccupantMenu (line 314)
+      - const renderOccupantMenu = (payload: OccupantContextMenuState): JSX.Element =>
+    - App (line 485)
+      - const App = (): JSX.Element =>
+    - isEditableElement (line 689)
+      - const isEditableElement = (element: Element | null): boolean =>
+    - commitDraft (line 702)
+      - const commitDraft = (next: string) =>
+    - handleGlobalKeyDown (line 712)
+      - const handleGlobalKeyDown = (event: KeyboardEvent): void =>
+    - buildSlots (line 926)
+      - const buildSlots = (userId: string | null) =>
+    - handleSlotChange (line 943)
+      - const handleSlotChange = (slotIndex: number, value: string) =>
+    - handleSlotClear (line 967)
+      - const handleSlotClear = (slotIndex: number) =>
+    - handleReadinessToggle (line 990)
+      - const handleReadinessToggle = (next: boolean) =>
+    - parseTimestamp (line 1190)
+      - const parseTimestamp = (value?: string | null): number =>
+    - handlePointerDown (line 1341)
+      - const handlePointerDown = (event: PointerEvent): void =>
+    - handleKeyDown (line 1360)
+      - const handleKeyDown = (event: KeyboardEvent): void =>
+    - handleScroll (line 1383)
+      - const handleScroll = (): void =>
+    - handleMenuButtonClick (line 1998)
+      - const handleMenuButtonClick = (label: string): void =>
+
+- **packages/client/src/canvas/constants.ts**
+
+- **packages/client/src/canvas/geometry.ts**
+  - Exports: buildGridDefinition, createTileKey, findTileAtPoint, getColumnsForRow, isPointInsideTile, toScreenPosition
+  - Imports: ./constants, ./types
+  - Functions:
+    - createTileKey (line 17)
+      - const createTileKey = (gridX: number, gridY: number): string =>
+    - getColumnsForRow (line 19) [exported]
+      - const getColumnsForRow = (row: number): number =>
+    - getMaxColumns (line 22)
+      - const getMaxColumns = (): number =>
+    - getRowOffset (line 24)
+      - const getRowOffset = (row: number): number =>
+    - getRowRightSpan (line 29)
+      - const getRowRightSpan = (row: number): number =>
+    - computeMaxRowSpan (line 35)
+      - const computeMaxRowSpan = (rowCount: number): number =>
+    - buildGridDefinition (line 48) [exported]
+      - const buildGridDefinition = (canvasWidth: number = CANVAS_WIDTH, canvasHeight: number = CANVAS_HEIGHT): GridDefinition =>
+    - isPointInsideTile (line 113) [exported]
+      - const isPointInsideTile = (tile: GridTile, px: number, py: number): boolean =>
+    - findTileAtPoint (line 120) [exported]
+      - const findTileAtPoint = (grid: GridDefinition, px: number, py: number): GridTile | null =>
+    - toScreenPosition (line 167) [exported]
+      - const toScreenPosition = (grid: GridDefinition, gridX: number, gridY: number): { x: number; y: number } =>
+
+- **packages/client/src/canvas/GridCanvas.tsx**
+  - Exports: default
+  - Imports: ../assets/avatars/avatar1.png, ../assets/avatars/avatar2.png, ../assets/rooms/dev_room.png, ./constants, ./geometry, ./types, react
+  - Functions:
+    - loadImage (line 165)
+      - async const loadImage = (source: string): Promise<HTMLImageElement> =>
+    - easeOutCubic (line 173)
+      - const easeOutCubic = (t: number): number =>
+    - prepareContext (line 175)
+      - const prepareContext = (canvas: HTMLCanvasElement): CanvasRenderingContext2D | null =>
+    - drawBackground (line 198)
+      - const drawBackground = (context: CanvasRenderingContext2D, assets: SpriteAssets | null): void =>
+    - traceDiamond (line 209)
+      - const traceDiamond = (context: CanvasRenderingContext2D, tile: GridTile): void =>
+    - drawTile (line 218)
+      - const drawTile = (context: CanvasRenderingContext2D, tile: GridTile, options: { hovered: boolean; locked: boolean; pending: boolean; noPickup: boolean }): void =>
+    - drawHiddenHoverTile (line 257)
+      - const drawHiddenHoverTile = (context: CanvasRenderingContext2D, tile: GridTile): void =>
+    - drawUsername (line 272)
+      - const drawUsername = (context: CanvasRenderingContext2D, sprite: OccupantRenderState): void =>
+    - splitLongWord (line 287)
+      - const splitLongWord = (context: CanvasRenderingContext2D, word: string, maxWidth: number): string[] =>
+    - wrapBubbleLines (line 311)
+      - const wrapBubbleLines = (context: CanvasRenderingContext2D, text: string, maxWidth: number): string[] =>
+    - pushLine (line 328)
+      - const pushLine = (line: string) =>
+    - drawSpeechBubble (line 374)
+      - const drawSpeechBubble = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, options: {
+    text: string;
+    fill: string;
+    textColor: string;
+    offset: number;
+  }): void =>
+    - drawTypingBubble (line 450)
+      - const drawTypingBubble = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, indicator: CanvasTypingIndicator): void =>
+    - drawChatBubbleForSprite (line 464)
+      - const drawChatBubbleForSprite = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, bubble: CanvasChatBubble): void =>
+    - drawOccupant (line 477)
+      - const drawOccupant = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, assets: SpriteAssets | null): void =>
+    - updateSpritePositions (line 508)
+      - const updateSpritePositions = (sprites: Map<string, OccupantRenderState>, now: number, animationsEnabled: boolean): void =>
+    - getAvatarVariantIndex (line 536)
+      - const getAvatarVariantIndex = (occupant: CanvasOccupant): number =>
+    - formatCoordinate (line 553)
+      - const formatCoordinate = (value: number): string =>
+    - GridCanvas (line 555)
+      - const GridCanvas = ({
+  occupants,
+  tileFlags,
+  pendingMoveTarget,
+  onTileClick,
+  items,
+  onTileContextMenu,
+  onItemContextMenu,
+  onOccupantContextMenu,
+  localOccupantId = null,
+  showGrid,
+  showHoverWhenGridHidden,
+  moveAnimationsEnabled,
+  typingIndicators,
+  chatBubbles,
+}: GridCanvasProps): JSX.Element =>
+    - loadAssets (line 628)
+      - async const loadAssets = (): Promise<void> =>
+    - loadItemAssets (line 666)
+      - async const loadItemAssets = (): Promise<void> =>
+    - renderFrame (line 855)
+      - const renderFrame = (timestamp: number): void =>
+    - handlePointerMove (line 1015)
+      - const handlePointerMove = (event: PointerEvent): void =>
+    - handlePointerLeave (line 1034)
+      - const handlePointerLeave = (): void =>
+    - handlePointerDown (line 1040)
+      - const handlePointerDown = (event: PointerEvent): void =>
+    - handleContextMenu (line 1057)
+      - const handleContextMenu = (event: MouseEvent): void =>
+    - getTileItems (line 1066)
+      - const getTileItems = (tile: GridTile | null): CanvasItem[] =>
+
+- **packages/client/src/canvas/types.ts**
+
+- **packages/client/src/components/InventoryCard.tsx**
+  - Exports: default
+  - Functions:
+    - InventoryCard (line 13)
+      - const InventoryCard = ({ items }: InventoryCardProps): JSX.Element =>
+
+- **packages/client/src/components/ProfilePanel.tsx**
+  - Exports: default
+  - Imports: ../ws/useRealtimeConnection
+  - Functions:
+    - ProfilePanel (line 15)
+      - const ProfilePanel = ({ state, onRetry, onClose }: ProfilePanelProps): JSX.Element | null =>
+
+- **packages/client/src/hooks/useActionToast.ts**
+  - Exports: useActionToast
+  - Imports: react
+  - Functions:
+    - useActionToast (line 15) [exported]
+      - const useActionToast = (timeoutMs = 4000): UseActionToastResult =>
+
+- **packages/client/src/main.tsx**
+  - Imports: ./App.js, react, react-dom/client
+
+  - _Output truncated due to markdownMaxPerGroup limit._

--- a/codemap.json
+++ b/codemap.json
@@ -1,0 +1,2638 @@
+{
+  "generatedAt": "2025-09-26T21:01:08.130Z",
+  "options": {
+    "fast": false
+  },
+  "files": [
+    {
+      "path": "packages/client/src/App.tsx",
+      "size": 77093,
+      "checksum": "a30d01aca0a6462e222ffcbdf3a96b5fdeae2687eee5bb0eee421d5560dede24",
+      "tags": [],
+      "imports": [
+        "./assets/items/couch.png",
+        "./assets/items/plant.png",
+        "./canvas/GridCanvas",
+        "./canvas/geometry",
+        "./canvas/types",
+        "./components/InventoryCard",
+        "./components/ProfilePanel",
+        "./hooks/useActionToast",
+        "./styles.css",
+        "./ws/useRealtimeConnection",
+        "react"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "adjustPosition",
+            "line": 164,
+            "exported": false,
+            "signature": "const adjustPosition = (): void =>"
+          },
+          {
+            "name": "renderTileSection",
+            "line": 248,
+            "exported": false,
+            "signature": "const renderTileSection = (tile: GridTile, items: CanvasItem[], focusedItemId: string | null): JSX.Element =>"
+          },
+          {
+            "name": "renderTileMenu",
+            "line": 311,
+            "exported": false,
+            "signature": "const renderTileMenu = (payload: TileContextMenuState): JSX.Element =>"
+          },
+          {
+            "name": "renderOccupantMenu",
+            "line": 314,
+            "exported": false,
+            "signature": "const renderOccupantMenu = (payload: OccupantContextMenuState): JSX.Element =>"
+          },
+          {
+            "name": "App",
+            "line": 485,
+            "exported": false,
+            "signature": "const App = (): JSX.Element =>"
+          },
+          {
+            "name": "isEditableElement",
+            "line": 689,
+            "exported": false,
+            "signature": "const isEditableElement = (element: Element | null): boolean =>"
+          },
+          {
+            "name": "commitDraft",
+            "line": 702,
+            "exported": false,
+            "signature": "const commitDraft = (next: string) =>"
+          },
+          {
+            "name": "handleGlobalKeyDown",
+            "line": 712,
+            "exported": false,
+            "signature": "const handleGlobalKeyDown = (event: KeyboardEvent): void =>"
+          },
+          {
+            "name": "buildSlots",
+            "line": 926,
+            "exported": false,
+            "signature": "const buildSlots = (userId: string | null) =>"
+          },
+          {
+            "name": "handleSlotChange",
+            "line": 943,
+            "exported": false,
+            "signature": "const handleSlotChange = (slotIndex: number, value: string) =>"
+          },
+          {
+            "name": "handleSlotClear",
+            "line": 967,
+            "exported": false,
+            "signature": "const handleSlotClear = (slotIndex: number) =>"
+          },
+          {
+            "name": "handleReadinessToggle",
+            "line": 990,
+            "exported": false,
+            "signature": "const handleReadinessToggle = (next: boolean) =>"
+          },
+          {
+            "name": "parseTimestamp",
+            "line": 1190,
+            "exported": false,
+            "signature": "const parseTimestamp = (value?: string | null): number =>"
+          },
+          {
+            "name": "handlePointerDown",
+            "line": 1341,
+            "exported": false,
+            "signature": "const handlePointerDown = (event: PointerEvent): void =>"
+          },
+          {
+            "name": "handleKeyDown",
+            "line": 1360,
+            "exported": false,
+            "signature": "const handleKeyDown = (event: KeyboardEvent): void =>"
+          },
+          {
+            "name": "handleScroll",
+            "line": 1383,
+            "exported": false,
+            "signature": "const handleScroll = (): void =>"
+          },
+          {
+            "name": "handleMenuButtonClick",
+            "line": 1998,
+            "exported": false,
+            "signature": "const handleMenuButtonClick = (label: string): void =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/canvas/constants.ts",
+      "size": 1005,
+      "checksum": "888f4b251415118fee0663dc0d08c7af868ec589c71bb2b81c97524f3820c50d",
+      "tags": [],
+      "imports": [],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/canvas/geometry.ts",
+      "size": 4468,
+      "checksum": "4984dccc2fe101a788debb89714d06eaacc5ccaf5bd4e2ea7586b2275428e0f3",
+      "tags": [],
+      "imports": [
+        "./constants",
+        "./types"
+      ],
+      "namedExports": [
+        "buildGridDefinition",
+        "createTileKey",
+        "findTileAtPoint",
+        "getColumnsForRow",
+        "isPointInsideTile",
+        "toScreenPosition"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createTileKey",
+            "line": 17,
+            "exported": false,
+            "signature": "const createTileKey = (gridX: number, gridY: number): string =>"
+          },
+          {
+            "name": "getColumnsForRow",
+            "line": 19,
+            "exported": true,
+            "signature": "const getColumnsForRow = (row: number): number =>"
+          },
+          {
+            "name": "getMaxColumns",
+            "line": 22,
+            "exported": false,
+            "signature": "const getMaxColumns = (): number =>"
+          },
+          {
+            "name": "getRowOffset",
+            "line": 24,
+            "exported": false,
+            "signature": "const getRowOffset = (row: number): number =>"
+          },
+          {
+            "name": "getRowRightSpan",
+            "line": 29,
+            "exported": false,
+            "signature": "const getRowRightSpan = (row: number): number =>"
+          },
+          {
+            "name": "computeMaxRowSpan",
+            "line": 35,
+            "exported": false,
+            "signature": "const computeMaxRowSpan = (rowCount: number): number =>"
+          },
+          {
+            "name": "buildGridDefinition",
+            "line": 48,
+            "exported": true,
+            "signature": "const buildGridDefinition = (canvasWidth: number = CANVAS_WIDTH, canvasHeight: number = CANVAS_HEIGHT): GridDefinition =>"
+          },
+          {
+            "name": "isPointInsideTile",
+            "line": 113,
+            "exported": true,
+            "signature": "const isPointInsideTile = (tile: GridTile, px: number, py: number): boolean =>"
+          },
+          {
+            "name": "findTileAtPoint",
+            "line": 120,
+            "exported": true,
+            "signature": "const findTileAtPoint = (grid: GridDefinition, px: number, py: number): GridTile | null =>"
+          },
+          {
+            "name": "toScreenPosition",
+            "line": 167,
+            "exported": true,
+            "signature": "const toScreenPosition = (grid: GridDefinition, gridX: number, gridY: number): { x: number; y: number } =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/canvas/GridCanvas.tsx",
+      "size": 36693,
+      "checksum": "1f045a9d8e8be2cbb83cc75b6b915af566b4f2f1452feb2dcee49b4b561c311e",
+      "tags": [],
+      "imports": [
+        "../assets/avatars/avatar1.png",
+        "../assets/avatars/avatar2.png",
+        "../assets/rooms/dev_room.png",
+        "./constants",
+        "./geometry",
+        "./types",
+        "react"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "loadImage",
+            "line": 165,
+            "exported": false,
+            "signature": "async const loadImage = (source: string): Promise<HTMLImageElement> =>"
+          },
+          {
+            "name": "easeOutCubic",
+            "line": 173,
+            "exported": false,
+            "signature": "const easeOutCubic = (t: number): number =>"
+          },
+          {
+            "name": "prepareContext",
+            "line": 175,
+            "exported": false,
+            "signature": "const prepareContext = (canvas: HTMLCanvasElement): CanvasRenderingContext2D | null =>"
+          },
+          {
+            "name": "drawBackground",
+            "line": 198,
+            "exported": false,
+            "signature": "const drawBackground = (context: CanvasRenderingContext2D, assets: SpriteAssets | null): void =>"
+          },
+          {
+            "name": "traceDiamond",
+            "line": 209,
+            "exported": false,
+            "signature": "const traceDiamond = (context: CanvasRenderingContext2D, tile: GridTile): void =>"
+          },
+          {
+            "name": "drawTile",
+            "line": 218,
+            "exported": false,
+            "signature": "const drawTile = (context: CanvasRenderingContext2D, tile: GridTile, options: { hovered: boolean; locked: boolean; pending: boolean; noPickup: boolean }): void =>"
+          },
+          {
+            "name": "drawHiddenHoverTile",
+            "line": 257,
+            "exported": false,
+            "signature": "const drawHiddenHoverTile = (context: CanvasRenderingContext2D, tile: GridTile): void =>"
+          },
+          {
+            "name": "drawUsername",
+            "line": 272,
+            "exported": false,
+            "signature": "const drawUsername = (context: CanvasRenderingContext2D, sprite: OccupantRenderState): void =>"
+          },
+          {
+            "name": "splitLongWord",
+            "line": 287,
+            "exported": false,
+            "signature": "const splitLongWord = (context: CanvasRenderingContext2D, word: string, maxWidth: number): string[] =>"
+          },
+          {
+            "name": "wrapBubbleLines",
+            "line": 311,
+            "exported": false,
+            "signature": "const wrapBubbleLines = (context: CanvasRenderingContext2D, text: string, maxWidth: number): string[] =>"
+          },
+          {
+            "name": "pushLine",
+            "line": 328,
+            "exported": false,
+            "signature": "const pushLine = (line: string) =>"
+          },
+          {
+            "name": "drawSpeechBubble",
+            "line": 374,
+            "exported": false,
+            "signature": "const drawSpeechBubble = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, options: {\n    text: string;\n    fill: string;\n    textColor: string;\n    offset: number;\n  }): void =>"
+          },
+          {
+            "name": "drawTypingBubble",
+            "line": 450,
+            "exported": false,
+            "signature": "const drawTypingBubble = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, indicator: CanvasTypingIndicator): void =>"
+          },
+          {
+            "name": "drawChatBubbleForSprite",
+            "line": 464,
+            "exported": false,
+            "signature": "const drawChatBubbleForSprite = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, bubble: CanvasChatBubble): void =>"
+          },
+          {
+            "name": "drawOccupant",
+            "line": 477,
+            "exported": false,
+            "signature": "const drawOccupant = (context: CanvasRenderingContext2D, sprite: OccupantRenderState, assets: SpriteAssets | null): void =>"
+          },
+          {
+            "name": "updateSpritePositions",
+            "line": 508,
+            "exported": false,
+            "signature": "const updateSpritePositions = (sprites: Map<string, OccupantRenderState>, now: number, animationsEnabled: boolean): void =>"
+          },
+          {
+            "name": "getAvatarVariantIndex",
+            "line": 536,
+            "exported": false,
+            "signature": "const getAvatarVariantIndex = (occupant: CanvasOccupant): number =>"
+          },
+          {
+            "name": "formatCoordinate",
+            "line": 553,
+            "exported": false,
+            "signature": "const formatCoordinate = (value: number): string =>"
+          },
+          {
+            "name": "GridCanvas",
+            "line": 555,
+            "exported": false,
+            "signature": "const GridCanvas = ({\n  occupants,\n  tileFlags,\n  pendingMoveTarget,\n  onTileClick,\n  items,\n  onTileContextMenu,\n  onItemContextMenu,\n  onOccupantContextMenu,\n  localOccupantId = null,\n  showGrid,\n  showHoverWhenGridHidden,\n  moveAnimationsEnabled,\n  typingIndicators,\n  chatBubbles,\n}: GridCanvasProps): JSX.Element =>"
+          },
+          {
+            "name": "loadAssets",
+            "line": 628,
+            "exported": false,
+            "signature": "async const loadAssets = (): Promise<void> =>"
+          },
+          {
+            "name": "loadItemAssets",
+            "line": 666,
+            "exported": false,
+            "signature": "async const loadItemAssets = (): Promise<void> =>"
+          },
+          {
+            "name": "renderFrame",
+            "line": 855,
+            "exported": false,
+            "signature": "const renderFrame = (timestamp: number): void =>"
+          },
+          {
+            "name": "handlePointerMove",
+            "line": 1015,
+            "exported": false,
+            "signature": "const handlePointerMove = (event: PointerEvent): void =>"
+          },
+          {
+            "name": "handlePointerLeave",
+            "line": 1034,
+            "exported": false,
+            "signature": "const handlePointerLeave = (): void =>"
+          },
+          {
+            "name": "handlePointerDown",
+            "line": 1040,
+            "exported": false,
+            "signature": "const handlePointerDown = (event: PointerEvent): void =>"
+          },
+          {
+            "name": "handleContextMenu",
+            "line": 1057,
+            "exported": false,
+            "signature": "const handleContextMenu = (event: MouseEvent): void =>"
+          },
+          {
+            "name": "getTileItems",
+            "line": 1066,
+            "exported": false,
+            "signature": "const getTileItems = (tile: GridTile | null): CanvasItem[] =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/canvas/types.ts",
+      "size": 661,
+      "checksum": "9eac3fd40ab9a53d9a7b052d77be46ee19d702fe83c0679e31fc36cc493a8194",
+      "tags": [],
+      "imports": [],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/components/InventoryCard.tsx",
+      "size": 1281,
+      "checksum": "6a67c20752b8a451bcc1263d99b83923bb39b09fd4b87dd6be9dd422c960aa01",
+      "tags": [],
+      "imports": [],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "InventoryCard",
+            "line": 13,
+            "exported": false,
+            "signature": "const InventoryCard = ({ items }: InventoryCardProps): JSX.Element =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/components/ProfilePanel.tsx",
+      "size": 3130,
+      "checksum": "a5a8035995c5daf83f544d5cb99e6df960d107f1e6faf9bf699f93e3ce0051c7",
+      "tags": [],
+      "imports": [
+        "../ws/useRealtimeConnection"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "ProfilePanel",
+            "line": 15,
+            "exported": false,
+            "signature": "const ProfilePanel = ({ state, onRetry, onClose }: ProfilePanelProps): JSX.Element | null =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/hooks/useActionToast.ts",
+      "size": 1217,
+      "checksum": "b8d2a4fe065fd9438372661b17233e08c240daccc0e6cf750adae8704340be91",
+      "tags": [],
+      "imports": [
+        "react"
+      ],
+      "namedExports": [
+        "useActionToast"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "useActionToast",
+            "line": 15,
+            "exported": true,
+            "signature": "const useActionToast = (timeoutMs = 4000): UseActionToastResult =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/main.tsx",
+      "size": 306,
+      "checksum": "ee0a7b37abf47d03ccae4a7c6d4bb1c120fecfff164a445017868b6e65c6d8c6",
+      "tags": [],
+      "imports": [
+        "./App.js",
+        "react",
+        "react-dom/client"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/src/ws/useRealtimeConnection.ts",
+      "size": 74569,
+      "checksum": "24ac5d275d561e80ae1928c7f969ee4787f0b5bf34076f8ebccbb1b22e9a8196",
+      "tags": [],
+      "imports": [
+        "@bitby/schemas",
+        "react",
+        "socket.io-client"
+      ],
+      "namedExports": [
+        "useRealtimeConnection"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "sortRoomItems",
+            "line": 70,
+            "exported": false,
+            "signature": "const sortRoomItems = (items: Iterable<RoomItem>): RoomItem[] =>"
+          },
+          {
+            "name": "sortInventoryItems",
+            "line": 78,
+            "exported": false,
+            "signature": "const sortInventoryItems = (items: Iterable<InventoryItem>): InventoryItem[] =>"
+          },
+          {
+            "name": "isSessionUser",
+            "line": 108,
+            "exported": false,
+            "signature": "const isSessionUser = (value: unknown): value is SessionUser =>"
+          },
+          {
+            "name": "isSessionRoom",
+            "line": 123,
+            "exported": false,
+            "signature": "const isSessionRoom = (value: unknown): value is SessionRoom =>"
+          },
+          {
+            "name": "cloneOccupant",
+            "line": 250,
+            "exported": false,
+            "signature": "const cloneOccupant = (occupant: RoomOccupant): RoomOccupant =>"
+          },
+          {
+            "name": "sortOccupants",
+            "line": 256,
+            "exported": false,
+            "signature": "const sortOccupants = (map: Map<string, RoomOccupant>): RoomOccupant[] =>"
+          },
+          {
+            "name": "buildEnvelope",
+            "line": 267,
+            "exported": false,
+            "signature": "const buildEnvelope = (seq: number, op: string, data: Record<string, unknown> = {}): MessageEnvelope =>"
+          },
+          {
+            "name": "normaliseSocketProtocol",
+            "line": 283,
+            "exported": false,
+            "signature": "const normaliseSocketProtocol = (protocol: string): string =>"
+          },
+          {
+            "name": "resolveSocketEndpoint",
+            "line": 294,
+            "exported": false,
+            "signature": "const resolveSocketEndpoint = (): SocketEndpoint =>"
+          },
+          {
+            "name": "resolveHttpBaseUrl",
+            "line": 320,
+            "exported": false,
+            "signature": "const resolveHttpBaseUrl = (): string =>"
+          },
+          {
+            "name": "getExplicitToken",
+            "line": 335,
+            "exported": false,
+            "signature": "const getExplicitToken = (): string | null =>"
+          },
+          {
+            "name": "getDevCredentials",
+            "line": 340,
+            "exported": false,
+            "signature": "const getDevCredentials = (): { username: string; password: string } =>"
+          },
+          {
+            "name": "getLatestPendingTarget",
+            "line": 345,
+            "exported": false,
+            "signature": "const getLatestPendingTarget = (pendingMoves: Map<number, { to: { x: number; y: number } }>): { x: number; y: number } | null =>"
+          },
+          {
+            "name": "normaliseTypingPreview",
+            "line": 355,
+            "exported": false,
+            "signature": "const normaliseTypingPreview = (input: string | null | undefined): string | null =>"
+          },
+          {
+            "name": "snapshotTypingIndicators",
+            "line": 366,
+            "exported": false,
+            "signature": "const snapshotTypingIndicators = (source: Map<string, TypingIndicatorInternal>): TypingIndicatorView[] =>"
+          },
+          {
+            "name": "snapshotChatBubbles",
+            "line": 375,
+            "exported": false,
+            "signature": "const snapshotChatBubbles = (source: Map<string, ChatBubbleInternal>): ChatBubbleView[] =>"
+          },
+          {
+            "name": "useRealtimeConnection",
+            "line": 385,
+            "exported": true,
+            "signature": "const useRealtimeConnection = (): RealtimeConnectionState =>"
+          },
+          {
+            "name": "clearPingTimer",
+            "line": 445,
+            "exported": false,
+            "signature": "const clearPingTimer = () =>"
+          },
+          {
+            "name": "clearCountdownTimer",
+            "line": 452,
+            "exported": false,
+            "signature": "const clearCountdownTimer = () =>"
+          },
+          {
+            "name": "clearTypingCleanupTimer",
+            "line": 459,
+            "exported": false,
+            "signature": "const clearTypingCleanupTimer = () =>"
+          },
+          {
+            "name": "clearBubbleCleanupTimer",
+            "line": 466,
+            "exported": false,
+            "signature": "const clearBubbleCleanupTimer = () =>"
+          },
+          {
+            "name": "abortLogin",
+            "line": 473,
+            "exported": false,
+            "signature": "const abortLogin = () =>"
+          },
+          {
+            "name": "clearActiveSocket",
+            "line": 481,
+            "exported": false,
+            "signature": "const clearActiveSocket = () =>"
+          },
+          {
+            "name": "startPingTimer",
+            "line": 504,
+            "exported": false,
+            "signature": "const startPingTimer = (intervalMs: number) =>"
+          },
+          {
+            "name": "updateState",
+            "line": 520,
+            "exported": false,
+            "signature": "const updateState = (partial: Partial<InternalConnectionState>) =>"
+          },
+          {
+            "name": "requestAuthToken",
+            "line": 543,
+            "exported": false,
+            "signature": "async const requestAuthToken = (): Promise<string> =>"
+          },
+          {
+            "name": "scheduleReconnect",
+            "line": 638,
+            "exported": false,
+            "signature": "const scheduleReconnect = () =>"
+          },
+          {
+            "name": "filterChatLogByMuted",
+            "line": 698,
+            "exported": false,
+            "signature": "const filterChatLogByMuted = (log: ChatMessageBroadcast[], mutedIds: Set<string>): ChatMessageBroadcast[] =>"
+          },
+          {
+            "name": "appendChatMessage",
+            "line": 706,
+            "exported": false,
+            "signature": "const appendChatMessage = (message: ChatMessageBroadcast) =>"
+          },
+          {
+            "name": "publishTypingIndicators",
+            "line": 725,
+            "exported": false,
+            "signature": "const publishTypingIndicators = () =>"
+          },
+          {
+            "name": "pruneTypingIndicators",
+            "line": 729,
+            "exported": false,
+            "signature": "const pruneTypingIndicators = (now: number = Date.now()): void =>"
+          },
+          {
+            "name": "scheduleTypingCleanup",
+            "line": 742,
+            "exported": false,
+            "signature": "const scheduleTypingCleanup = () =>"
+          },
+          {
+            "name": "upsertTypingIndicator",
+            "line": 753,
+            "exported": false,
+            "signature": "const upsertTypingIndicator = (userId: string, preview: string | null, expiresAt?: number): void =>"
+          },
+          {
+            "name": "removeTypingIndicator",
+            "line": 770,
+            "exported": false,
+            "signature": "const removeTypingIndicator = (userId: string): void =>"
+          },
+          {
+            "name": "publishChatBubbles",
+            "line": 779,
+            "exported": false,
+            "signature": "const publishChatBubbles = () =>"
+          },
+          {
+            "name": "pruneChatBubbles",
+            "line": 783,
+            "exported": false,
+            "signature": "const pruneChatBubbles = (now: number = Date.now()): void =>"
+          },
+          {
+            "name": "scheduleBubbleCleanup",
+            "line": 796,
+            "exported": false,
+            "signature": "const scheduleBubbleCleanup = () =>"
+          },
+          {
+            "name": "upsertChatBubble",
+            "line": 807,
+            "exported": false,
+            "signature": "const upsertChatBubble = (userId: string, messageId: string, body: string): void =>"
+          },
+          {
+            "name": "removeChatBubble",
+            "line": 817,
+            "exported": false,
+            "signature": "const removeChatBubble = (userId: string): void =>"
+          },
+          {
+            "name": "handleEnvelope",
+            "line": 826,
+            "exported": false,
+            "signature": "const handleEnvelope = (envelope: MessageEnvelope) =>"
+          },
+          {
+            "name": "connect",
+            "line": 1476,
+            "exported": false,
+            "signature": "async const connect = () =>"
+          },
+          {
+            "name": "detachListeners",
+            "line": 1533,
+            "exported": false,
+            "signature": "const detachListeners = () =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/vite.config.ts",
+      "size": 630,
+      "checksum": "45180ffcfc7fe71fd17bfac8ad4f9cf2b6ca3d737341bea9d5d0fd92c94cbbc0",
+      "tags": [],
+      "imports": [
+        "@vitejs/plugin-react",
+        "node:path",
+        "node:url",
+        "vite"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/vitest.config.ts",
+      "size": 628,
+      "checksum": "5f1a4e83a66c208796d2b4ee6b10abe77fb3e190b2cc43d70726fd7bfd36ffb6",
+      "tags": [],
+      "imports": [
+        "@vitejs/plugin-react",
+        "node:path",
+        "node:url",
+        "vitest/config"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/client/vitest.setup.ts",
+      "size": 43,
+      "checksum": "91a3c8962a0edcb956206a501d943fe99e1c78c6d4d8b5c9a948a3362c75978c",
+      "tags": [],
+      "imports": [
+        "@testing-library/jest-dom/vitest"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/index.ts",
+      "size": 351,
+      "checksum": "b96f0dfc1d4250e8ae603d6bfe0f1627c7d9ac66c87ffb8ec1b30633cf36e4e4",
+      "tags": [],
+      "imports": [],
+      "namedExports": [
+        "*"
+      ],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/openapi/auth.ts",
+      "size": 3069,
+      "checksum": "ff4b1f9e89ae2a70dac7beb2133baaf2fc675475867e7938f8d4aac84af8d447",
+      "tags": [],
+      "imports": [
+        "openapi-types"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/rest/occupants.ts",
+      "size": 3433,
+      "checksum": "d5a66860f1d0653cfca70aad2ee36bfd5c4a221d857d1491b7fb1c89a5aedd52",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/admin.ts",
+      "size": 1872,
+      "checksum": "2a7d8fbd6e9c3ba61525ca5649676d9885094121cc38e6603d7693e3b11608f9",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/auth.ts",
+      "size": 463,
+      "checksum": "01f7434830f74eeb8bcfdceeff5b8d16032ad407239e4741ea6ba4d9e5e313eb",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/chat.ts",
+      "size": 3213,
+      "checksum": "fa80b0dcebbfb9204f426bec17579e3445bb4f94ba7d23dc61b9910ffc99bc41",
+      "tags": [],
+      "imports": [
+        "./envelope.js",
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/envelope.ts",
+      "size": 639,
+      "checksum": "297a16ea2a24c7aaed6aa072ce16a0c72f4ff9925141b869f52311403bd2f872",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [
+        "buildEnvelopeSchema"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "buildEnvelopeSchema",
+            "line": 17,
+            "exported": true,
+            "signature": "const buildEnvelopeSchema = (dataSchema: Schema) =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/items.ts",
+      "size": 2210,
+      "checksum": "000b6391e19fd49166c6385be124b6b61b8313a37fb53767ca380f14651289c1",
+      "tags": [],
+      "imports": [
+        "./room.js",
+        "zod"
+      ],
+      "namedExports": [
+        "roomItemSchema"
+      ],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/move.ts",
+      "size": 2708,
+      "checksum": "b82f541a9640b48f4387e748ea6472c4140dae79a592b2be57e30f2f9a278e51",
+      "tags": [],
+      "imports": [
+        "./envelope.js",
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/room.ts",
+      "size": 2377,
+      "checksum": "6a0a6a7b3dd77beb0950dcbc556d20511ed5cfb32df0969bb8b02739fcbac665",
+      "tags": [],
+      "imports": [
+        "./admin.js",
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/social.ts",
+      "size": 1156,
+      "checksum": "df438462f948428d281837ca92b9bfe3631776bb36597f936d563c259ce13ba9",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/schemas/src/ws/trade.ts",
+      "size": 444,
+      "checksum": "8c6317e17c6fdeb2b73f50bc1a0a3cff0791d0632022505bb8ab7aa9641fca15",
+      "tags": [],
+      "imports": [
+        "../rest/occupants.js",
+        "zod"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/__tests__/helpers/testStack.ts",
+      "size": 3969,
+      "checksum": "721180cc70cd8d1a3848c1c99297f50a3d7a8ca1ac6618f32384f4ef31021ca9",
+      "tags": [],
+      "imports": [
+        "@testcontainers/postgresql",
+        "@testcontainers/redis",
+        "ioredis",
+        "pg"
+      ],
+      "namedExports": [
+        "startTestStack"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "parseInteger",
+            "line": 9,
+            "exported": false,
+            "signature": "const parseInteger = (value: string | undefined, fallback: number): number =>"
+          },
+          {
+            "name": "buildRedisFlusher",
+            "line": 37,
+            "exported": false,
+            "signature": "const buildRedisFlusher = (redisUrl: string) =>"
+          },
+          {
+            "name": "attemptExternalStack",
+            "line": 46,
+            "exported": false,
+            "signature": "async const attemptExternalStack = (): Promise<TestStack | null> =>"
+          },
+          {
+            "name": "startContainerStack",
+            "line": 108,
+            "exported": false,
+            "signature": "async const startContainerStack = (): Promise<TestStack> =>"
+          },
+          {
+            "name": "startTestStack",
+            "line": 138,
+            "exported": true,
+            "signature": "async const startTestStack = (): Promise<TestStack> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/api/admin.ts",
+      "size": 11348,
+      "checksum": "6425998b3cf08964f9afbcc582cbb6135ae069a604586666d32f7c2eda884eaf",
+      "tags": [],
+      "imports": [
+        "../auth/http.js",
+        "../auth/jwt.js",
+        "../auth/types.js",
+        "../config.js",
+        "../db/admin.js",
+        "../db/audit.js",
+        "../db/items.js",
+        "../db/rooms.js",
+        "../ws/connection.js",
+        "fastify",
+        "node:crypto",
+        "zod"
+      ],
+      "namedExports": [
+        "adminRoutes"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "isTileInBounds",
+            "line": 69,
+            "exported": false,
+            "signature": "const isTileInBounds = (x: number, y: number): boolean =>"
+          },
+          {
+            "name": "adminRoutes",
+            "line": 78,
+            "exported": true,
+            "signature": "const adminRoutes = (app, options, done) =>"
+          },
+          {
+            "name": "requireAdmin",
+            "line": 87,
+            "exported": false,
+            "signature": "async const requireAdmin = (request: FastifyRequest, reply: FastifyReply): Promise<AuthenticatedUser | null> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/api/auth.ts",
+      "size": 1662,
+      "checksum": "1f9b006c8871e0a57c933d20bfbe6133e3449fc295c44d1d13e366afd427395c",
+      "tags": [],
+      "imports": [
+        "../auth/jwt.js",
+        "../auth/store.js",
+        "../config.js",
+        "fastify",
+        "zod"
+      ],
+      "namedExports": [
+        "authRoutes"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "authRoutes",
+            "line": 17,
+            "exported": true,
+            "signature": "async const authRoutes = (app: FastifyInstance, options: AuthPluginOptions): Promise<void> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/api/occupants.ts",
+      "size": 23751,
+      "checksum": "5aa35a7064f6452b3693689ea5a43faaf73ec04b03ce9093d8b5ed972ae4f5b3",
+      "tags": [],
+      "imports": [
+        "../auth/http.js",
+        "../auth/jwt.js",
+        "../config.js",
+        "../db/items.js",
+        "../db/rooms.js",
+        "../db/social.js",
+        "../ws/connection.js",
+        "fastify",
+        "zod"
+      ],
+      "namedExports": [
+        "occupantRoutes"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "occupantRoutes",
+            "line": 62,
+            "exported": true,
+            "signature": "const occupantRoutes = (app, options, done) =>"
+          },
+          {
+            "name": "requireAuth",
+            "line": 69,
+            "exported": false,
+            "signature": "const requireAuth = (request: FastifyRequest): { userId: string } | null =>"
+          },
+          {
+            "name": "resolveOccupantContext",
+            "line": 84,
+            "exported": false,
+            "signature": "async const resolveOccupantContext = (roomId: string, occupantId: string, requesterId: string) =>"
+          },
+          {
+            "name": "resolveTradeContext",
+            "line": 107,
+            "exported": false,
+            "signature": "async const resolveTradeContext = (roomId: string, tradeId: string, requesterId: string) =>"
+          },
+          {
+            "name": "mapTradeRecord",
+            "line": 134,
+            "exported": false,
+            "signature": "const mapTradeRecord = (trade: TradeSessionRecord) =>"
+          },
+          {
+            "name": "mapTradeProposal",
+            "line": 150,
+            "exported": false,
+            "signature": "const mapTradeProposal = (proposal: TradeProposalRecord) =>"
+          },
+          {
+            "name": "buildNegotiationState",
+            "line": 163,
+            "exported": false,
+            "signature": "async const buildNegotiationState = (tradeId: string) =>"
+          },
+          {
+            "name": "resolveTradeParticipant",
+            "line": 171,
+            "exported": false,
+            "signature": "async const resolveTradeParticipant = (params: {\n    trade: TradeSessionRecord;\n    requesterId: string;\n  }) =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/auth/http.ts",
+      "size": 289,
+      "checksum": "41f81dd09961fbfa05a8da57c57cde772785714a7d63f9de8710c33bd8655bb7",
+      "tags": [],
+      "imports": [],
+      "namedExports": [
+        "extractBearerToken"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "extractBearerToken",
+            "line": 1,
+            "exported": true,
+            "signature": "const extractBearerToken = (authorization?: string): string | null =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/auth/jwt.ts",
+      "size": 1534,
+      "checksum": "226d5bfab498885e36b171934a8b3cef06e42a3cb435bbe16990fac26ed965b6",
+      "tags": [],
+      "imports": [
+        "../config.js",
+        "./types.js",
+        "jsonwebtoken"
+      ],
+      "namedExports": [
+        "decodeToken",
+        "signToken"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "assertValidClaims",
+            "line": 11,
+            "exported": false,
+            "signature": "function assertValidClaims(claims: TokenClaims): asserts claims is TokenClaims & { sub: string; username: string }"
+          },
+          {
+            "name": "signToken",
+            "line": 23,
+            "exported": true,
+            "signature": "const signToken = (user: PublicUser, config: ServerConfig): string =>"
+          },
+          {
+            "name": "decodeToken",
+            "line": 37,
+            "exported": true,
+            "signature": "const decodeToken = (token: string, config: ServerConfig): AuthenticatedUser =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/auth/store.ts",
+      "size": 1615,
+      "checksum": "3606ab1ac081c068c497c26908f3ef17e772281635da88e2d2914b7f95230135",
+      "tags": [],
+      "imports": [
+        "./types.js",
+        "argon2",
+        "pg"
+      ],
+      "namedExports": [
+        "createUserStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "normaliseUsername",
+            "line": 11,
+            "exported": false,
+            "signature": "const normaliseUsername = (username: string): string =>"
+          },
+          {
+            "name": "createUserStore",
+            "line": 13,
+            "exported": true,
+            "signature": "const createUserStore = (pool: Pool): UserStore =>"
+          },
+          {
+            "name": "findUserByUsername",
+            "line": 14,
+            "exported": false,
+            "signature": "async const findUserByUsername = (username: string): Promise<UserRecord | null> =>"
+          },
+          {
+            "name": "toPublicUser",
+            "line": 41,
+            "exported": false,
+            "signature": "const toPublicUser = (user: UserRecord): PublicUser =>"
+          },
+          {
+            "name": "verifyUserPassword",
+            "line": 47,
+            "exported": false,
+            "signature": "async const verifyUserPassword = (user: UserRecord, password: string): Promise<boolean> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/auth/types.ts",
+      "size": 1052,
+      "checksum": "ceba5748a90427b29a8cfd1e4cb71afdd5720cd65ad9f5c196c5976b822d684d",
+      "tags": [],
+      "imports": [],
+      "namedExports": [],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/config.ts",
+      "size": 3425,
+      "checksum": "ca7c32fb97b517186b50513e923245a21d39564d5a16dfa8d45b45148cd0238c",
+      "tags": [],
+      "imports": [
+        "zod"
+      ],
+      "namedExports": [
+        "loadConfig",
+        "resolveCorsOrigins"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "numericEnv",
+            "line": 3,
+            "exported": false,
+            "signature": "const numericEnv = (value: unknown, defaultValue: number): number =>"
+          },
+          {
+            "name": "buildOrigin",
+            "line": 60,
+            "exported": false,
+            "signature": "const buildOrigin = (protocol: string, hostname: string, port: string): string =>"
+          },
+          {
+            "name": "resolveCorsOrigins",
+            "line": 67,
+            "exported": true,
+            "signature": "const resolveCorsOrigins = (origin: string): string | string[] =>"
+          },
+          {
+            "name": "addVariant",
+            "line": 80,
+            "exported": false,
+            "signature": "const addVariant = (value: string): void =>"
+          },
+          {
+            "name": "loadConfig",
+            "line": 94,
+            "exported": true,
+            "signature": "const loadConfig = (env: NodeJS.ProcessEnv = process.env): ServerConfig =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/admin.ts",
+      "size": 5613,
+      "checksum": "ac9438c6c304ee3efc734b4f80350a53d4d169f52389a21136ad1787243f1350",
+      "tags": [],
+      "imports": [
+        "pg"
+      ],
+      "namedExports": [
+        "createAdminStateStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "mapRow",
+            "line": 39,
+            "exported": false,
+            "signature": "const mapRow = (row: {\n  room_id: string;\n  grid_visible: boolean | null;\n  show_hover_when_grid_hidden: boolean | null;\n  move_animations_enabled: boolean | null;\n  last_latency_trace_id: string | null;\n  last_latency_trace_requested_at: Date | string | null;\n  last_latency_trace_requested_by: string | null;\n}): RoomAdminStateRecord =>"
+          },
+          {
+            "name": "serialiseTrace",
+            "line": 76,
+            "exported": false,
+            "signature": "const serialiseTrace = (trace: LatencyTraceState | null): {\n  id: string | null;\n  requestedAt: Date | null;\n  requestedBy: string | null;\n} =>"
+          },
+          {
+            "name": "createAdminStateStore",
+            "line": 91,
+            "exported": true,
+            "signature": "const createAdminStateStore = (pool: Pool): AdminStateStore =>"
+          },
+          {
+            "name": "getRoomState",
+            "line": 92,
+            "exported": false,
+            "signature": "async const getRoomState = (roomId: string): Promise<RoomAdminStateRecord> =>"
+          },
+          {
+            "name": "upsertState",
+            "line": 109,
+            "exported": false,
+            "signature": "async const upsertState = (roomId: string, next: RoomAdminStateRecord): Promise<RoomAdminStateRecord> =>"
+          },
+          {
+            "name": "updateAffordances",
+            "line": 148,
+            "exported": false,
+            "signature": "async const updateAffordances = (roomId: string, updates: Partial<DevAffordanceState>): Promise<RoomAdminStateRecord> =>"
+          },
+          {
+            "name": "recordLatencyTrace",
+            "line": 164,
+            "exported": false,
+            "signature": "async const recordLatencyTrace = (roomId: string, trace: { traceId: string; requestedAt: Date; requestedBy: string | null }): Promise<RoomAdminStateRecord> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/audit.ts",
+      "size": 2461,
+      "checksum": "774a7b41f1b1fd2bbf3f9ed546919eaf5434f17a54c853749c2e78d2092c6744",
+      "tags": [],
+      "imports": [
+        "pg"
+      ],
+      "namedExports": [
+        "createAuditLogStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "parseContext",
+            "line": 25,
+            "exported": false,
+            "signature": "const parseContext = (raw: unknown): Record<string, unknown> =>"
+          },
+          {
+            "name": "mapRow",
+            "line": 33,
+            "exported": false,
+            "signature": "const mapRow = (row: {\n  id: number;\n  user_id: string;\n  room_id: string | null;\n  action: string;\n  ctx: unknown;\n  created_at: Date | string;\n}): AuditLogRecord =>"
+          },
+          {
+            "name": "createAuditLogStore",
+            "line": 50,
+            "exported": true,
+            "signature": "const createAuditLogStore = (pool: Pool): AuditLogStore =>"
+          },
+          {
+            "name": "recordAdminAction",
+            "line": 51,
+            "exported": false,
+            "signature": "async const recordAdminAction = ({\n    userId,\n    roomId,\n    action,\n    context,\n  }) =>"
+          },
+          {
+            "name": "listRecentAdminActions",
+            "line": 67,
+            "exported": false,
+            "signature": "async const listRecentAdminActions = (options = {}) =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/chat.ts",
+      "size": 3737,
+      "checksum": "b949cc46d29eb863edf7ef3adc6050e8875ea1227748f16228444469be777672",
+      "tags": [],
+      "imports": [
+        "pg"
+      ],
+      "namedExports": [
+        "createChatStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "mapRow",
+            "line": 28,
+            "exported": false,
+            "signature": "const mapRow = (row: {\n  id: string;\n  room_id: string;\n  user_id: string;\n  username: string;\n  roles: string[] | null;\n  body: string;\n  created_at: Date;\n  room_seq: string | number;\n}): ChatMessageRecord =>"
+          },
+          {
+            "name": "createChatStore",
+            "line": 48,
+            "exported": true,
+            "signature": "const createChatStore = (pool: Pool): ChatStore =>"
+          },
+          {
+            "name": "createMessage",
+            "line": 49,
+            "exported": false,
+            "signature": "async const createMessage = ({\n    id,\n    roomId,\n    userId,\n    body,\n    roomSeq,\n  }: {\n    id: string;\n    roomId: string;\n    userId: string;\n    body: string;\n    roomSeq: number;\n  }): Promise<ChatMessageRecord> =>"
+          },
+          {
+            "name": "listRecentMessages",
+            "line": 83,
+            "exported": false,
+            "signature": "async const listRecentMessages = (roomId: string, limit: number): Promise<ChatMessageRecord[]> =>"
+          },
+          {
+            "name": "pruneMessagesForRoom",
+            "line": 109,
+            "exported": false,
+            "signature": "async const pruneMessagesForRoom = ({\n    roomId,\n    retain,\n  }) =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/items.ts",
+      "size": 8422,
+      "checksum": "6b8c090cdc6659c09186227fab1e7eb134510c652ac3ddf4daa4532fa6287c71",
+      "tags": [],
+      "imports": [
+        "node:crypto",
+        "pg"
+      ],
+      "namedExports": [
+        "createItemStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "mapRoomItemRow",
+            "line": 53,
+            "exported": false,
+            "signature": "const mapRoomItemRow = (row: {\n  id: string;\n  room_id: string;\n  name: string;\n  description: string;\n  texture_key: string;\n  tile_x: number;\n  tile_y: number;\n  picked_up_at: Date | string | null;\n  picked_up_by: string | null;\n}): RoomItemRecord =>"
+          },
+          {
+            "name": "mapInventoryRow",
+            "line": 75,
+            "exported": false,
+            "signature": "const mapInventoryRow = (row: {\n  id: string;\n  user_id: string;\n  room_item_id: string;\n  room_id: string;\n  acquired_at: Date | string;\n}): {\n  id: string;\n  userId: string;\n  roomItemId: string;\n  roomId: string;\n  acquiredAt: Date;\n} =>"
+          },
+          {
+            "name": "withTransaction",
+            "line": 95,
+            "exported": false,
+            "signature": "async const withTransaction = (pool: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> =>"
+          },
+          {
+            "name": "createItemStore",
+            "line": 115,
+            "exported": true,
+            "signature": "const createItemStore = (pool: Pool): ItemStore =>"
+          },
+          {
+            "name": "listRoomItems",
+            "line": 116,
+            "exported": false,
+            "signature": "async const listRoomItems = (roomId: string): Promise<RoomItemRecord[]> =>"
+          },
+          {
+            "name": "listInventoryForUser",
+            "line": 138,
+            "exported": false,
+            "signature": "async const listInventoryForUser = (userId: string): Promise<InventoryItemRecord[]> =>"
+          },
+          {
+            "name": "attemptPickup",
+            "line": 166,
+            "exported": false,
+            "signature": "async const attemptPickup = ({\n    itemId,\n    userId,\n    roomId,\n  }: {\n    itemId: string;\n    userId: string;\n    roomId: string;\n  }): Promise<ItemPickupResult> =>"
+          },
+          {
+            "name": "createRoomItem",
+            "line": 263,
+            "exported": false,
+            "signature": "async const createRoomItem = ({\n    roomId,\n    name,\n    description,\n    textureKey,\n    tileX,\n    tileY,\n    id,\n  }: {\n    roomId: string;\n    name: string;\n    description: string;\n    textureKey: string;\n    tileX: number;\n    tileY: number;\n    id?: string;\n  }): Promise<RoomItemRecord> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/migrations.ts",
+      "size": 14073,
+      "checksum": "bd770dcbda58f53b3d18504b0338d2604d35d880ad79f712089c62f46cbc1a33",
+      "tags": [],
+      "imports": [
+        "./social.js",
+        "pg"
+      ],
+      "namedExports": [
+        "runMigrations"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "escapeSqlString",
+            "line": 68,
+            "exported": false,
+            "signature": "const escapeSqlString = (value: string): string =>"
+          },
+          {
+            "name": "ensureMigrationTable",
+            "line": 308,
+            "exported": false,
+            "signature": "async const ensureMigrationTable = (pool: Pool): Promise<void> =>"
+          },
+          {
+            "name": "hasMigrationRun",
+            "line": 317,
+            "exported": false,
+            "signature": "async const hasMigrationRun = (client: PoolClient, id: string): Promise<boolean> =>"
+          },
+          {
+            "name": "recordMigration",
+            "line": 325,
+            "exported": false,
+            "signature": "async const recordMigration = (client: PoolClient, id: string): Promise<void> =>"
+          },
+          {
+            "name": "runMigrations",
+            "line": 332,
+            "exported": true,
+            "signature": "async const runMigrations = (pool: Pool): Promise<void> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/pool.ts",
+      "size": 485,
+      "checksum": "215bb8a4e1d8a78eb9f1833059f4c81b60b795ad5f08e8d29463e0b7ac8404ba",
+      "tags": [],
+      "imports": [
+        "../config.js",
+        "pg"
+      ],
+      "namedExports": [
+        "createPgPool"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createPgPool",
+            "line": 4,
+            "exported": true,
+            "signature": "const createPgPool = (config: ServerConfig): Pool =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/preferences.ts",
+      "size": 1618,
+      "checksum": "3e0e6adebaecaf57b19d669d668b08dfb457634658a889bac4c79846cebb489b",
+      "tags": [],
+      "imports": [
+        "pg"
+      ],
+      "namedExports": [
+        "createPreferenceStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createPreferenceStore",
+            "line": 16,
+            "exported": true,
+            "signature": "const createPreferenceStore = (pool: Pool): PreferenceStore =>"
+          },
+          {
+            "name": "getChatPreferences",
+            "line": 17,
+            "exported": false,
+            "signature": "async const getChatPreferences = (userId: string): Promise<ChatPreferenceRecord> =>"
+          },
+          {
+            "name": "updateChatShowSystemMessages",
+            "line": 31,
+            "exported": false,
+            "signature": "async const updateChatShowSystemMessages = (userId: string, showSystemMessages: boolean): Promise<ChatPreferenceRecord> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/rooms.ts",
+      "size": 7185,
+      "checksum": "7b0ea90f644fa87e86469726cc7b121788bd298a14cd6b9a244cd1bdef91e22e",
+      "tags": [],
+      "imports": [
+        "../auth/types.js",
+        "pg"
+      ],
+      "namedExports": [
+        "createRoomStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "mapRoomRow",
+            "line": 42,
+            "exported": false,
+            "signature": "const mapRoomRow = (row: {\n  id: string;\n  slug: string;\n  name: string;\n  room_seq: string | number;\n}): RoomRecord =>"
+          },
+          {
+            "name": "mapOccupantRow",
+            "line": 54,
+            "exported": false,
+            "signature": "const mapOccupantRow = (row: {\n  id: string;\n  username: string;\n  roles: string[] | null;\n  x: number;\n  y: number;\n  room_id?: string | null;\n}): RoomSnapshotOccupant & { roomId: string | null } =>"
+          },
+          {
+            "name": "createRoomStore",
+            "line": 69,
+            "exported": true,
+            "signature": "const createRoomStore = (pool: Pool): RoomStore =>"
+          },
+          {
+            "name": "getRoomBySlug",
+            "line": 70,
+            "exported": false,
+            "signature": "async const getRoomBySlug = (slug: string): Promise<RoomRecord | null> =>"
+          },
+          {
+            "name": "getRoomById",
+            "line": 83,
+            "exported": false,
+            "signature": "async const getRoomById = (id: string): Promise<RoomRecord | null> =>"
+          },
+          {
+            "name": "getTileFlags",
+            "line": 96,
+            "exported": false,
+            "signature": "async const getTileFlags = (roomId: string): Promise<TileFlagRecord[]> =>"
+          },
+          {
+            "name": "getTileFlag",
+            "line": 110,
+            "exported": false,
+            "signature": "async const getTileFlag = (roomId: string, x: number, y: number): Promise<TileFlagRecord | null> =>"
+          },
+          {
+            "name": "updateTileFlag",
+            "line": 131,
+            "exported": false,
+            "signature": "async const updateTileFlag = (roomId: string, x: number, y: number, updates: Partial<Omit<TileFlagRecord, 'x' | 'y'>>): Promise<TileFlagRecord> =>"
+          },
+          {
+            "name": "listOccupants",
+            "line": 157,
+            "exported": false,
+            "signature": "async const listOccupants = (roomId: string): Promise<RoomSnapshotOccupant[]> =>"
+          },
+          {
+            "name": "getOccupant",
+            "line": 180,
+            "exported": false,
+            "signature": "async const getOccupant = (userId: string): Promise<RoomOccupantRecord | null> =>"
+          },
+          {
+            "name": "upsertOccupantPosition",
+            "line": 204,
+            "exported": false,
+            "signature": "async const upsertOccupantPosition = (userId: string, roomId: string, position: { x: number; y: number }): Promise<RoomSnapshotOccupant> =>"
+          },
+          {
+            "name": "clearOccupant",
+            "line": 227,
+            "exported": false,
+            "signature": "async const clearOccupant = (userId: string): Promise<void> =>"
+          },
+          {
+            "name": "incrementRoomSequence",
+            "line": 231,
+            "exported": false,
+            "signature": "async const incrementRoomSequence = (roomId: string): Promise<number> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/db/social.ts",
+      "size": 22128,
+      "checksum": "cfaeb38996a819ae3c6fc5984f6286ccf2391394a99af945b4c9ba344a32ff19",
+      "tags": [],
+      "imports": [
+        "node:crypto",
+        "pg"
+      ],
+      "namedExports": [
+        "createSocialStore"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createSocialStore",
+            "line": 105,
+            "exported": true,
+            "signature": "const createSocialStore = (pool: Pool): SocialStore =>"
+          },
+          {
+            "name": "mapTradeRow",
+            "line": 108,
+            "exported": false,
+            "signature": "const mapTradeRow = (row: {\n    id: string;\n    initiator_id: string;\n    recipient_id: string;\n    room_id: string;\n    status: 'pending' | 'accepted' | 'completed' | 'cancelled';\n    created_at: Date | string;\n    accepted_at: Date | string | null;\n    completed_at: Date | string | null;\n    cancelled_at: Date | string | null;\n    cancelled_by: string | null;\n    cancelled_reason: 'cancelled' | 'declined' | null;\n    initiator_ready: boolean;\n    recipient_ready: boolean;\n  }): TradeSessionRecord =>"
+          },
+          {
+            "name": "createTradeSession",
+            "line": 138,
+            "exported": false,
+            "signature": "async const createTradeSession = ({\n    initiatorId,\n    recipientId,\n    roomId,\n  }) =>"
+          },
+          {
+            "name": "getTradeSessionById",
+            "line": 168,
+            "exported": false,
+            "signature": "async const getTradeSessionById = (tradeId) =>"
+          },
+          {
+            "name": "getLatestTradeSessionForUser",
+            "line": 198,
+            "exported": false,
+            "signature": "async const getLatestTradeSessionForUser = (userId) =>"
+          },
+          {
+            "name": "updateTradeSessionStatus",
+            "line": 233,
+            "exported": false,
+            "signature": "async const updateTradeSessionStatus = ({\n    tradeId,\n    actorId,\n    status,\n    reason,\n  }) =>"
+          },
+          {
+            "name": "updateTradeParticipantReadiness",
+            "line": 349,
+            "exported": false,
+            "signature": "async const updateTradeParticipantReadiness = ({\n    tradeId,\n    actorId,\n    ready,\n  }) =>"
+          },
+          {
+            "name": "listTradeProposalsForTrade",
+            "line": 419,
+            "exported": false,
+            "signature": "async const listTradeProposalsForTrade = (tradeId) =>"
+          },
+          {
+            "name": "removeTradeProposalsForItem",
+            "line": 454,
+            "exported": false,
+            "signature": "async const removeTradeProposalsForItem = (tradeId: string, inventoryItemId: string) =>"
+          },
+          {
+            "name": "resetReadinessForParticipant",
+            "line": 463,
+            "exported": false,
+            "signature": "async const resetReadinessForParticipant = (tradeId: string, participantId: string) =>"
+          },
+          {
+            "name": "upsertTradeProposal",
+            "line": 473,
+            "exported": false,
+            "signature": "async const upsertTradeProposal = ({\n    tradeId,\n    offeredBy,\n    slotIndex,\n    inventoryItemId,\n  }) =>"
+          },
+          {
+            "name": "removeTradeProposal",
+            "line": 556,
+            "exported": false,
+            "signature": "async const removeTradeProposal = ({\n    tradeId,\n    offeredBy,\n    slotIndex,\n  }) =>"
+          },
+          {
+            "name": "recordMute",
+            "line": 590,
+            "exported": false,
+            "signature": "async const recordMute = ({\n    userId,\n    mutedUserId,\n    roomId,\n  }) =>"
+          },
+          {
+            "name": "recordReport",
+            "line": 622,
+            "exported": false,
+            "signature": "async const recordReport = ({\n    reporterId,\n    reportedUserId,\n    roomId,\n    reason,\n  }) =>"
+          },
+          {
+            "name": "getUserProfile",
+            "line": 654,
+            "exported": false,
+            "signature": "async const getUserProfile = (userId) =>"
+          },
+          {
+            "name": "listMutesForUser",
+            "line": 681,
+            "exported": false,
+            "signature": "async const listMutesForUser = (userId) =>"
+          },
+          {
+            "name": "listReportsByUser",
+            "line": 705,
+            "exported": false,
+            "signature": "async const listReportsByUser = (userId) =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/index.ts",
+      "size": 1240,
+      "checksum": "0b7657040863cdb6b8b381c8366e577e225889f78647c40cf0b1641c37f2d54d",
+      "tags": [],
+      "imports": [
+        "./config.js",
+        "./readiness.js",
+        "./server.js",
+        "dotenv/config"
+      ],
+      "namedExports": [],
+      "symbols": {
+        "functions": [
+          {
+            "name": "bootstrap",
+            "line": 6,
+            "exported": false,
+            "signature": "async const bootstrap = (): Promise<void> =>"
+          },
+          {
+            "name": "close",
+            "line": 11,
+            "exported": false,
+            "signature": "async const close = () =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/metrics/registry.ts",
+      "size": 1115,
+      "checksum": "2c4e476dce673ba3b836c8875582754bbbf22f38acfedf928bf9485d3cdcfd57",
+      "tags": [],
+      "imports": [
+        "prom-client"
+      ],
+      "namedExports": [
+        "createMetricsBundle"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createMetricsBundle",
+            "line": 11,
+            "exported": true,
+            "signature": "const createMetricsBundle = (): MetricsBundle =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/readiness.ts",
+      "size": 377,
+      "checksum": "e142da60c6e4e4bd780d2bda4735c81ddc7a050525024bcb38f21c70fae7eb39",
+      "tags": [],
+      "imports": [],
+      "namedExports": [
+        "createReadinessController"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createReadinessController",
+            "line": 7,
+            "exported": true,
+            "signature": "const createReadinessController = (): ReadinessController =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/redis/pubsub.ts",
+      "size": 4954,
+      "checksum": "c69df7840c73e1971382540ec3b1081ac3b60cb63e403a4b6911cd28a5beb602",
+      "tags": [],
+      "imports": [
+        "../config.js",
+        "../db/admin.js",
+        "../db/items.js",
+        "../db/rooms.js",
+        "@bitby/schemas",
+        "fastify",
+        "ioredis"
+      ],
+      "namedExports": [
+        "createRoomPubSub"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "ROOM_EVENT_CHANNEL",
+            "line": 13,
+            "exported": false,
+            "signature": "const ROOM_EVENT_CHANNEL = (roomId: string): string =>"
+          },
+          {
+            "name": "createRoomPubSub",
+            "line": 97,
+            "exported": true,
+            "signature": "async const createRoomPubSub = ({\n  config,\n  logger,\n  instanceId,\n}: {\n  config: ServerConfig;\n  logger: FastifyBaseLogger;\n  instanceId: string;\n}): Promise<RoomPubSub> =>"
+          },
+          {
+            "name": "publish",
+            "line": 121,
+            "exported": false,
+            "signature": "async const publish = (event: RoomEvent): Promise<void> =>"
+          },
+          {
+            "name": "subscribe",
+            "line": 126,
+            "exported": false,
+            "signature": "async const subscribe = (roomId: string, handler: (event: RoomEvent) => void): Promise<void> =>"
+          },
+          {
+            "name": "listener",
+            "line": 136,
+            "exported": false,
+            "signature": "const listener = (incomingChannel: string, payload: string) =>"
+          },
+          {
+            "name": "close",
+            "line": 172,
+            "exported": false,
+            "signature": "async const close = (): Promise<void> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/server.ts",
+      "size": 4039,
+      "checksum": "48f3940d64275fa7675eac246e7b408cf302d0ee75f5cc6daeef6671130bdaa3",
+      "tags": [],
+      "imports": [
+        "./api/admin.js",
+        "./api/auth.js",
+        "./api/occupants.js",
+        "./auth/store.js",
+        "./config.js",
+        "./db/admin.js",
+        "./db/audit.js",
+        "./db/chat.js",
+        "./db/items.js",
+        "./db/migrations.js",
+        "./db/pool.js",
+        "./db/preferences.js",
+        "./db/rooms.js",
+        "./db/social.js",
+        "./metrics/registry.js",
+        "./readiness.js",
+        "./redis/pubsub.js",
+        "./ws/connection.js",
+        "@fastify/cors",
+        "fastify",
+        "node:crypto",
+        "socket.io"
+      ],
+      "namedExports": [
+        "createServer"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createServer",
+            "line": 32,
+            "exported": true,
+            "signature": "async const createServer = ({\n  config,\n  readiness,\n}: CreateServerOptions): Promise<FastifyInstance> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/src/ws/connection.ts",
+      "size": 58004,
+      "checksum": "b9c63b7bd09c1925367b90f6d3e31e8bf4d534322be5e1dd234dbc1f2196638b",
+      "tags": [],
+      "imports": [
+        "../auth/jwt.js",
+        "../auth/types.js",
+        "../config.js",
+        "../db/admin.js",
+        "../db/chat.js",
+        "../db/items.js",
+        "../db/preferences.js",
+        "../db/rooms.js",
+        "../db/social.js",
+        "../metrics/registry.js",
+        "../redis/pubsub.js",
+        "@bitby/schemas",
+        "fastify",
+        "node:crypto",
+        "socket.io",
+        "zod"
+      ],
+      "namedExports": [
+        "createRealtimeServer"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "createTileKey",
+            "line": 218,
+            "exported": false,
+            "signature": "const createTileKey = (x: number, y: number): string =>"
+          },
+          {
+            "name": "getColumnsForRow",
+            "line": 220,
+            "exported": false,
+            "signature": "const getColumnsForRow = (row: number): number =>"
+          },
+          {
+            "name": "toUnixTimestamp",
+            "line": 223,
+            "exported": false,
+            "signature": "const toUnixTimestamp = () =>"
+          },
+          {
+            "name": "createEnvelope",
+            "line": 225,
+            "exported": false,
+            "signature": "const createEnvelope = (op: string, seq: number, data: EnvelopeData = {}): Envelope =>"
+          },
+          {
+            "name": "toRoomItem",
+            "line": 232,
+            "exported": false,
+            "signature": "const toRoomItem = (record: RoomItemRecord): RoomItem =>"
+          },
+          {
+            "name": "toInventoryPayload",
+            "line": 241,
+            "exported": false,
+            "signature": "const toInventoryPayload = (record: InventoryItemRecord): InventoryItemPayload =>"
+          },
+          {
+            "name": "toMutePayload",
+            "line": 251,
+            "exported": false,
+            "signature": "const toMutePayload = (record: MuteRecord): SocialMutePayload =>"
+          },
+          {
+            "name": "toReportPayload",
+            "line": 259,
+            "exported": false,
+            "signature": "const toReportPayload = (record: ReportRecord): SocialReportPayload =>"
+          },
+          {
+            "name": "toTradePayload",
+            "line": 268,
+            "exported": false,
+            "signature": "const toTradePayload = (record: TradeSessionRecord): TradeLifecyclePayload =>"
+          },
+          {
+            "name": "toTradeProposalPayload",
+            "line": 284,
+            "exported": false,
+            "signature": "const toTradeProposalPayload = (record: TradeProposalRecord) =>"
+          },
+          {
+            "name": "cloneOccupant",
+            "line": 297,
+            "exported": false,
+            "signature": "const cloneOccupant = (occupant: RoomOccupant): RoomOccupant =>"
+          },
+          {
+            "name": "cloneItem",
+            "line": 304,
+            "exported": false,
+            "signature": "const cloneItem = (item: RoomItem): RoomItem =>"
+          },
+          {
+            "name": "sortOccupants",
+            "line": 313,
+            "exported": false,
+            "signature": "const sortOccupants = (map: Map<string, RoomOccupant>): RoomOccupant[] =>"
+          },
+          {
+            "name": "sortItems",
+            "line": 324,
+            "exported": false,
+            "signature": "const sortItems = (map: Map<string, RoomItem>): RoomItem[] =>"
+          },
+          {
+            "name": "safeSend",
+            "line": 335,
+            "exported": false,
+            "signature": "const safeSend = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope): void =>"
+          },
+          {
+            "name": "acknowledge",
+            "line": 347,
+            "exported": false,
+            "signature": "const acknowledge = (logger: FastifyBaseLogger, socket: Socket, requestEnvelope: Envelope, op: string, data: EnvelopeData = {}): void =>"
+          },
+          {
+            "name": "emitSystemMessage",
+            "line": 357,
+            "exported": false,
+            "signature": "const emitSystemMessage = (logger: FastifyBaseLogger, socket: Socket, op: string, data: EnvelopeData): void =>"
+          },
+          {
+            "name": "createRealtimeServer",
+            "line": 366,
+            "exported": true,
+            "signature": "async const createRealtimeServer = ({\n  config,\n  roomStore,\n  chatStore,\n  itemStore,\n  pubsub,\n  metrics,\n  preferenceStore,\n  adminStateStore,\n  socialStore,\n}: RealtimeDependencies): Promise<RealtimeServer> =>"
+          },
+          {
+            "name": "updateRoomSeq",
+            "line": 406,
+            "exported": false,
+            "signature": "const updateRoomSeq = (roomSeq: number): void =>"
+          },
+          {
+            "name": "getOrCreateSocialState",
+            "line": 412,
+            "exported": false,
+            "signature": "const getOrCreateSocialState = (userId: string): UserSocialState =>"
+          },
+          {
+            "name": "serialiseSocialState",
+            "line": 421,
+            "exported": false,
+            "signature": "const serialiseSocialState = (userId: string): {\n    mutes: SocialMutePayload[];\n    reports: SocialReportPayload[];\n  } =>"
+          },
+          {
+            "name": "refreshSocialStateForUser",
+            "line": 432,
+            "exported": false,
+            "signature": "async const refreshSocialStateForUser = (userId: string) =>"
+          },
+          {
+            "name": "resolveTradeParticipantForUser",
+            "line": 451,
+            "exported": false,
+            "signature": "async const resolveTradeParticipantForUser = (params: {\n    trade: TradeLifecyclePayload;\n    requesterId: string;\n  }): Promise<TradeParticipantSummary> =>"
+          },
+          {
+            "name": "buildTradeNegotiationPayload",
+            "line": 477,
+            "exported": false,
+            "signature": "async const buildTradeNegotiationPayload = (tradeId: string): Promise<TradeNegotiationPayload> =>"
+          },
+          {
+            "name": "hydrateTradeLifecycleForUser",
+            "line": 487,
+            "exported": false,
+            "signature": "async const hydrateTradeLifecycleForUser = (userId: string): Promise<TradeLifecycleBroadcast | null> =>"
+          },
+          {
+            "name": "serialiseAdminState",
+            "line": 510,
+            "exported": false,
+            "signature": "const serialiseAdminState = (): {\n    affordances: AdminDevAffordanceState;\n    lastLatencyTrace: AdminLatencyTrace | null;\n  } =>"
+          },
+          {
+            "name": "buildSnapshot",
+            "line": 525,
+            "exported": false,
+            "signature": "const buildSnapshot = (): RoomSnapshot =>"
+          },
+          {
+            "name": "isTileLocked",
+            "line": 540,
+            "exported": false,
+            "signature": "const isTileLocked = (x: number, y: number): boolean =>"
+          },
+          {
+            "name": "isTileInBounds",
+            "line": 543,
+            "exported": false,
+            "signature": "const isTileInBounds = (x: number, y: number): boolean =>"
+          },
+          {
+            "name": "isTileOccupied",
+            "line": 552,
+            "exported": false,
+            "signature": "const isTileOccupied = (x: number, y: number, excludeUserId?: string): boolean =>"
+          },
+          {
+            "name": "findAvailableSpawn",
+            "line": 566,
+            "exported": false,
+            "signature": "const findAvailableSpawn = (): { x: number; y: number } =>"
+          },
+          {
+            "name": "ensureOccupant",
+            "line": 580,
+            "exported": false,
+            "signature": "async const ensureOccupant = (user: AuthenticatedUser): Promise<{ occupant: RoomOccupant; wasNew: boolean }> =>"
+          },
+          {
+            "name": "registerConnection",
+            "line": 618,
+            "exported": false,
+            "signature": "async const registerConnection = (logger: FastifyBaseLogger, socket: Socket, user: AuthenticatedUser): Promise<{\n    snapshot: RoomSnapshot;\n    occupant: RoomOccupant;\n    inventory: InventoryItemRecord[];\n    social: { mutes: SocialMutePayload[]; reports: SocialReportPayload[] };\n    tradeLifecycle: TradeLifecycleBroadcast | null;\n  }> =>"
+          },
+          {
+            "name": "emitSocialMuteUpdate",
+            "line": 645,
+            "exported": false,
+            "signature": "const emitSocialMuteUpdate = (payload: SocialMutePayload): void =>"
+          },
+          {
+            "name": "emitSocialReportUpdate",
+            "line": 659,
+            "exported": false,
+            "signature": "const emitSocialReportUpdate = (payload: SocialReportPayload): void =>"
+          },
+          {
+            "name": "emitTradeLifecycleUpdate",
+            "line": 673,
+            "exported": false,
+            "signature": "async const emitTradeLifecycleUpdate = (event: {\n    trade: TradeLifecyclePayload;\n    negotiation: TradeNegotiationPayload;\n    actorId?: string;\n  }): Promise<void> =>"
+          },
+          {
+            "name": "unregisterConnection",
+            "line": 713,
+            "exported": false,
+            "signature": "async const unregisterConnection = (socket: Socket): Promise<void> =>"
+          },
+          {
+            "name": "broadcastOccupantMove",
+            "line": 755,
+            "exported": false,
+            "signature": "const broadcastOccupantMove = (occupant: RoomOccupant, roomSeq: number, excludeSocketId?: string): void =>"
+          },
+          {
+            "name": "broadcastItemRemoved",
+            "line": 776,
+            "exported": false,
+            "signature": "const broadcastItemRemoved = (itemId: string, roomSeq: number, excludeSocketId?: string): void =>"
+          },
+          {
+            "name": "broadcastItemAdded",
+            "line": 797,
+            "exported": false,
+            "signature": "const broadcastItemAdded = (item: RoomItem, roomSeq: number, excludeSocketId?: string): void =>"
+          },
+          {
+            "name": "pruneTypingIndicators",
+            "line": 820,
+            "exported": false,
+            "signature": "const pruneTypingIndicators = (now: number = Date.now()): void =>"
+          },
+          {
+            "name": "serialiseTypingIndicators",
+            "line": 828,
+            "exported": false,
+            "signature": "const serialiseTypingIndicators = (): ChatTypingBroadcast[] =>"
+          },
+          {
+            "name": "broadcastTypingEvent",
+            "line": 840,
+            "exported": false,
+            "signature": "const broadcastTypingEvent = (payload: ChatTypingBroadcast, excludeSocketId?: string): void =>"
+          },
+          {
+            "name": "setTypingIndicator",
+            "line": 857,
+            "exported": false,
+            "signature": "const setTypingIndicator = (userId: string, preview: string | null): TypingIndicatorState =>"
+          },
+          {
+            "name": "clearTypingIndicator",
+            "line": 872,
+            "exported": false,
+            "signature": "const clearTypingIndicator = (userId: string): void =>"
+          },
+          {
+            "name": "broadcastChatEvent",
+            "line": 876,
+            "exported": false,
+            "signature": "const broadcastChatEvent = (event: RoomChatEvent): void =>"
+          },
+          {
+            "name": "broadcastTileFlagUpdate",
+            "line": 907,
+            "exported": false,
+            "signature": "const broadcastTileFlagUpdate = (tile: TileFlagRecord, roomSeq: number, updatedBy: string): void =>"
+          },
+          {
+            "name": "broadcastAffordanceUpdate",
+            "line": 926,
+            "exported": false,
+            "signature": "const broadcastAffordanceUpdate = (state: AdminDevAffordanceState, updatedBy: string): void =>"
+          },
+          {
+            "name": "broadcastLatencyTrace",
+            "line": 943,
+            "exported": false,
+            "signature": "const broadcastLatencyTrace = (trace: AdminLatencyTrace): void =>"
+          },
+          {
+            "name": "applyTileFlagUpdateInternal",
+            "line": 954,
+            "exported": false,
+            "signature": "async const applyTileFlagUpdateInternal = (event: { tile: TileFlagRecord; roomSeq: number; updatedBy: string }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyAffordanceUpdateInternal",
+            "line": 982,
+            "exported": false,
+            "signature": "async const applyAffordanceUpdateInternal = (event: { state: AdminDevAffordanceState; updatedBy: string }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyLatencyTraceInternal",
+            "line": 1002,
+            "exported": false,
+            "signature": "async const applyLatencyTraceInternal = (event: { trace: AdminLatencyTrace }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyItemSpawnInternal",
+            "line": 1035,
+            "exported": false,
+            "signature": "async const applyItemSpawnInternal = (event: { item: RoomItemRecord; roomSeq: number; createdBy: string }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyMuteRecordInternal",
+            "line": 1054,
+            "exported": false,
+            "signature": "async const applyMuteRecordInternal = (event: { mute: SocialMutePayload }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyReportRecordInternal",
+            "line": 1071,
+            "exported": false,
+            "signature": "async const applyReportRecordInternal = (event: { report: SocialReportPayload }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "applyTradeLifecycleInternal",
+            "line": 1088,
+            "exported": false,
+            "signature": "async const applyTradeLifecycleInternal = (event: { trade: TradeLifecyclePayload; negotiation: TradeNegotiationPayload; actorId?: string }, shouldPublish: boolean): Promise<void> =>"
+          },
+          {
+            "name": "attemptMove",
+            "line": 1194,
+            "exported": false,
+            "signature": "async const attemptMove = (userId: string, target: { x: number; y: number }): Promise<\n    | {\n        ok: true;\n        occupant: RoomOccupant;\n        roomSeq: number;\n      }\n    | {\n        ok: false;\n        code: MoveErrorCode;\n        message: string;\n        current: { x: number; y: number };\n        roomSeq: number;\n      }\n  > =>"
+          },
+          {
+            "name": "handleAuth",
+            "line": 1274,
+            "exported": false,
+            "signature": "async const handleAuth = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope, closeWithReason: (reason: string) => void): Promise<AuthenticatedUser | null> =>"
+          },
+          {
+            "name": "handleChatSend",
+            "line": 1357,
+            "exported": false,
+            "signature": "async const handleChatSend = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope, user: AuthenticatedUser): Promise<void> =>"
+          },
+          {
+            "name": "handleTypingUpdate",
+            "line": 1423,
+            "exported": false,
+            "signature": "async const handleTypingUpdate = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope, user: AuthenticatedUser): Promise<void> =>"
+          },
+          {
+            "name": "handleChatPreferenceUpdate",
+            "line": 1473,
+            "exported": false,
+            "signature": "async const handleChatPreferenceUpdate = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope, user: AuthenticatedUser): Promise<void> =>"
+          },
+          {
+            "name": "handleItemPickup",
+            "line": 1505,
+            "exported": false,
+            "signature": "async const handleItemPickup = (logger: FastifyBaseLogger, socket: Socket, envelope: Envelope, user: AuthenticatedUser): Promise<void> =>"
+          },
+          {
+            "name": "sendError",
+            "line": 1516,
+            "exported": false,
+            "signature": "const sendError = (code:\n        | 'validation_failed'\n        | 'not_in_room'\n        | 'not_found'\n        | 'tile_blocked'\n        | 'not_on_tile'\n        | 'already_picked_up'\n        | 'persist_failed', message: string, itemId: string): void =>"
+          },
+          {
+            "name": "handleConnection",
+            "line": 1617,
+            "exported": false,
+            "signature": "const handleConnection = ({ app, socket, requestId }: ConnectionContext): void =>"
+          },
+          {
+            "name": "closeWithReason",
+            "line": 1625,
+            "exported": false,
+            "signature": "const closeWithReason = (reason: string): void =>"
+          },
+          {
+            "name": "applyTileFlagUpdate",
+            "line": 1850,
+            "exported": false,
+            "signature": "async const applyTileFlagUpdate = (event: {\n    tile: TileFlagRecord;\n    roomSeq: number;\n    updatedBy: string;\n  }): Promise<void> =>"
+          },
+          {
+            "name": "applyAffordanceUpdate",
+            "line": 1858,
+            "exported": false,
+            "signature": "async const applyAffordanceUpdate = (event: {\n    state: AdminDevAffordanceState;\n    updatedBy: string;\n  }): Promise<void> =>"
+          },
+          {
+            "name": "applyLatencyTrace",
+            "line": 1865,
+            "exported": false,
+            "signature": "async const applyLatencyTrace = (event: { trace: AdminLatencyTrace }): Promise<void> =>"
+          },
+          {
+            "name": "applyItemSpawn",
+            "line": 1869,
+            "exported": false,
+            "signature": "async const applyItemSpawn = (event: {\n    item: RoomItemRecord;\n    roomSeq: number;\n    createdBy: string;\n  }): Promise<void> =>"
+          },
+          {
+            "name": "applyMuteRecord",
+            "line": 1877,
+            "exported": false,
+            "signature": "async const applyMuteRecord = (event: { record: MuteRecord }): Promise<void> =>"
+          },
+          {
+            "name": "applyReportRecord",
+            "line": 1882,
+            "exported": false,
+            "signature": "async const applyReportRecord = (event: { record: ReportRecord }): Promise<void> =>"
+          },
+          {
+            "name": "applyTradeLifecycleUpdate",
+            "line": 1887,
+            "exported": false,
+            "signature": "async const applyTradeLifecycleUpdate = (event: {\n    trade: TradeSessionRecord;\n    actorId: string;\n  }): Promise<void> =>"
+          },
+          {
+            "name": "shutdown",
+            "line": 1899,
+            "exported": false,
+            "signature": "async const shutdown = (): Promise<void> =>"
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
+      "path": "packages/server/vitest.config.ts",
+      "size": 286,
+      "checksum": "a88a9a74cf5ada387c1fd54fb98ba4d07e4ec02d1927e51454295c1393f1df28",
+      "tags": [],
+      "imports": [
+        "vitest/config"
+      ],
+      "namedExports": [
+        "default"
+      ],
+      "symbols": {
+        "functions": [],
+        "classes": [],
+        "methods": []
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "dev": "pnpm --filter @bitby/server dev",
     "lint": "pnpm -r run lint",
     "typecheck": "pnpm -r run typecheck",
-    "test": "pnpm -r run test"
+    "test": "pnpm -r run test",
+    "codemap": "tsx tools/codemap/generate.ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "globby": "^13.2.2",
     "prettier": "^3.2.5",
+    "tsx": "^4.7.2",
     "typescript": "^5.4.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,15 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.2(eslint@8.57.1)
+      globby:
+        specifier: ^13.2.2
+        version: 13.2.2
       prettier:
         specifier: ^3.2.5
         version: 3.6.2
+      tsx:
+        specifier: ^4.7.2
+        version: 4.20.5
       typescript:
         specifier: ^5.4.5
         version: 5.9.2
@@ -3124,6 +3130,17 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /globby@13.2.2:
+    resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 4.0.0
+    dev: true
+
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4627,6 +4644,11 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /slash@4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
     dev: true
 
   /socket.io-adapter@2.5.5:

--- a/tools/codemap/generate.ts
+++ b/tools/codemap/generate.ts
@@ -1,0 +1,571 @@
+// @module: codemap
+// @tags: tooling, ci
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { globby } from 'globby';
+import ts from 'typescript';
+
+interface CodemapConfig {
+  include: string[];
+  exclude: string[];
+  markdownMaxPerGroup?: number;
+}
+
+interface BaseSymbolEntry {
+  name: string;
+  line: number;
+  exported: boolean;
+  signature?: string;
+}
+
+interface MethodEntry extends BaseSymbolEntry {
+  className?: string;
+}
+
+interface ClassEntry extends BaseSymbolEntry {
+  methods: MethodEntry[];
+}
+
+interface FileEntry {
+  path: string;
+  size: number;
+  checksum: string;
+  module?: string;
+  tags: string[];
+  imports: string[];
+  namedExports: string[];
+  symbols: {
+    functions: BaseSymbolEntry[];
+    classes: ClassEntry[];
+    methods: MethodEntry[];
+  };
+}
+
+interface CodemapDocument {
+  generatedAt: string;
+  options: {
+    only?: string;
+    fast?: boolean;
+  };
+  files: FileEntry[];
+}
+
+const CONFIG_PATH = path.resolve(process.cwd(), '.codemaprc.json');
+const CODEMAP_PATH = path.resolve(process.cwd(), 'codemap.json');
+const CODEMAP_MARKDOWN_PATH = path.resolve(process.cwd(), 'CODEMAP.md');
+
+async function loadExistingCodemap(): Promise<CodemapDocument | null> {
+  try {
+    const raw = await fs.readFile(CODEMAP_PATH, 'utf8');
+    return JSON.parse(raw) as CodemapDocument;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function readConfig(): Promise<CodemapConfig> {
+  try {
+    const raw = await fs.readFile(CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<CodemapConfig>;
+    return {
+      include: parsed.include ?? ['packages/**/*.{ts,tsx,js,jsx}'],
+      exclude:
+        parsed.exclude ?? [
+          '**/node_modules/**',
+          '**/dist/**',
+          '**/.next/**',
+          '**/build/**',
+          '**/coverage/**',
+          '**/*.d.ts',
+          '**/*.test.*',
+          '**/*.spec.*',
+        ],
+      markdownMaxPerGroup: parsed.markdownMaxPerGroup ?? Infinity,
+    };
+  } catch (error) {
+    return {
+      include: ['packages/**/*.{ts,tsx,js,jsx}'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/.next/**',
+        '**/build/**',
+        '**/coverage/**',
+        '**/*.d.ts',
+        '**/*.test.*',
+        '**/*.spec.*',
+      ],
+      markdownMaxPerGroup: Infinity,
+    };
+  }
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let only: string | undefined;
+  let fast = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--only') {
+      const pattern = args[i + 1];
+      if (!pattern) {
+        throw new Error('Expected pattern after --only');
+      }
+      only = pattern;
+      i += 1;
+    } else if (arg === '--fast') {
+      fast = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { only, fast };
+}
+
+function checksum(content: string) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function getLine(node: ts.Node, source: ts.SourceFile): number {
+  return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+}
+
+function hasExportModifier(modifiers: readonly ts.ModifierLike[] | undefined): boolean {
+  return Boolean(modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword));
+}
+
+function hasDefaultModifier(modifiers: readonly ts.ModifierLike[] | undefined): boolean {
+  return Boolean(modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword));
+}
+
+function getFunctionSignature(
+  node: ts.FunctionLikeDeclarationBase,
+  source: ts.SourceFile,
+  assignedName?: string,
+): string {
+  const modifiers = (ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined)
+    ?.map((m) => m.getText(source))
+    .join(' ');
+  const name = ts.isConstructorDeclaration(node)
+    ? 'constructor'
+    : node.name?.getText(source) ?? assignedName ?? '(anonymous)';
+  const params = node.parameters.map((param) => param.getText(source)).join(', ');
+  const returnType = node.type ? `: ${node.type.getText(source)}` : '';
+  const keyword = ts.isArrowFunction(node)
+    ? '=>'
+    : ts.isMethodDeclaration(node)
+    ? ''
+    : 'function';
+  const prefix = modifiers ? `${modifiers} ` : '';
+  if (ts.isArrowFunction(node)) {
+    const typeAnnotation = node.type ? `: ${node.type.getText(source)}` : '';
+    const leftSide = assignedName ?? name;
+    return `${prefix}${leftSide} = (${params})${typeAnnotation} =>`;
+  }
+  if (ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) {
+    return `${prefix}${name}(${params})${returnType}`;
+  }
+  return `${prefix}${keyword} ${name}(${params})${returnType}`.trim();
+}
+
+function getClassSignature(node: ts.ClassDeclaration, source: ts.SourceFile): string {
+  const modifiers = node.modifiers?.map((m) => m.getText(source)).join(' ');
+  const name = node.name?.getText(source) ?? '(anonymous)';
+  const heritageClauses = node.heritageClauses?.map((clause) => clause.getText(source)).join(' ');
+  const prefix = modifiers ? `${modifiers} ` : '';
+  return [prefix + 'class ' + name, heritageClauses].filter(Boolean).join(' ');
+}
+
+function analyzeFile(filePath: string, sourceText: string, fast: boolean): FileEntry {
+  const extension = path.extname(filePath);
+  const source = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    extension === '.tsx'
+      ? ts.ScriptKind.TSX
+      : extension === '.jsx'
+      ? ts.ScriptKind.JSX
+      : ts.ScriptKind.TS,
+  );
+
+  const imports = new Set<string>();
+  const namedExports = new Set<string>();
+  const functions: BaseSymbolEntry[] = [];
+  const classes: ClassEntry[] = [];
+  const methods: MethodEntry[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node)) {
+      if (node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+        imports.add(node.moduleSpecifier.text);
+      }
+    }
+
+    if (ts.isExportDeclaration(node)) {
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const element of node.exportClause.elements) {
+          namedExports.add(element.name.getText(source));
+        }
+      } else if (!node.exportClause) {
+        // export * from 'module'
+        namedExports.add('*');
+      }
+    }
+
+    if (ts.isExportAssignment(node)) {
+      namedExports.add('default');
+    }
+
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      const exported = hasExportModifier(node.modifiers);
+      const entry: BaseSymbolEntry = {
+        name: node.name.getText(source),
+        line: getLine(node, source),
+        exported,
+      };
+      const isDefault = hasDefaultModifier(node.modifiers);
+      if (!fast) {
+        entry.signature = getFunctionSignature(node, source, entry.name);
+      }
+      functions.push(entry);
+      if (exported && node.name) {
+        namedExports.add(entry.name);
+        if (isDefault) {
+          namedExports.add('default');
+        }
+      }
+    }
+
+    if (ts.isVariableStatement(node)) {
+      const exported = hasExportModifier(node.modifiers);
+      for (const declaration of node.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
+          continue;
+        }
+        if (
+          ts.isArrowFunction(declaration.initializer) ||
+          ts.isFunctionExpression(declaration.initializer)
+        ) {
+          const funcNode = declaration.initializer;
+          const entry: BaseSymbolEntry = {
+            name: declaration.name.getText(source),
+            line: getLine(funcNode, source),
+            exported,
+          };
+          if (!fast) {
+            entry.signature = getFunctionSignature(funcNode, source, `const ${entry.name}`);
+          }
+          functions.push(entry);
+          if (exported) {
+            namedExports.add(entry.name);
+          }
+        }
+      }
+    }
+
+    if (ts.isClassDeclaration(node)) {
+      const exported = hasExportModifier(node.modifiers) || hasDefaultModifier(node.modifiers);
+      const classEntry: ClassEntry = {
+        name: node.name?.getText(source) ?? '(anonymous)',
+        line: getLine(node, source),
+        exported,
+        methods: [],
+      };
+      if (!fast) {
+        classEntry.signature = getClassSignature(node, source);
+      }
+      classes.push(classEntry);
+      if (node.name && exported) {
+        namedExports.add(classEntry.name);
+      }
+      if (exported && hasDefaultModifier(node.modifiers)) {
+        namedExports.add('default');
+      }
+
+      for (const member of node.members) {
+        if (
+          ts.isMethodDeclaration(member) ||
+          ts.isGetAccessorDeclaration(member) ||
+          ts.isSetAccessorDeclaration(member) ||
+          ts.isConstructorDeclaration(member)
+        ) {
+          const methodEntry: MethodEntry = {
+            name: member.name?.getText(source) ?? '(anonymous)',
+            line: getLine(member, source),
+            exported: hasExportModifier(member.modifiers),
+            className: classEntry.name,
+          };
+          if (!fast && (ts.isMethodDeclaration(member) || ts.isConstructorDeclaration(member))) {
+            methodEntry.signature = getFunctionSignature(member, source, `${classEntry.name}.${methodEntry.name}`);
+          }
+          classEntry.methods.push(methodEntry);
+          methods.push(methodEntry);
+        }
+      }
+    }
+
+    if (ts.isExportSpecifier(node)) {
+      namedExports.add(node.name.getText(source));
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+
+  const headerLines = sourceText.split(/\r?\n/).slice(0, 10);
+  const moduleHeader = headerLines.find((line) => line.trim().startsWith('// @module:'));
+  const tagsHeader = headerLines.find((line) => line.trim().startsWith('// @tags:'));
+
+  const moduleName = moduleHeader?.split(':')[1]?.trim();
+  const tags = tagsHeader
+    ? tagsHeader
+        .split(':')[1]
+        ?.split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0) ?? []
+    : [];
+
+  return {
+    path: path.relative(process.cwd(), filePath).replace(/\\/g, '/'),
+    size: Buffer.byteLength(sourceText, 'utf8'),
+    checksum: checksum(sourceText),
+    module: moduleName || undefined,
+    tags,
+    imports: Array.from(imports).sort(),
+    namedExports: Array.from(namedExports).sort(),
+    symbols: {
+      functions: functions.sort((a, b) => a.line - b.line),
+      classes: classes.sort((a, b) => a.line - b.line),
+      methods: methods.sort((a, b) => a.line - b.line),
+    },
+  };
+}
+
+function renderMarkdown(codemap: CodemapDocument, markdownMaxPerGroup: number, fast: boolean) {
+  const groups = new Map<string, FileEntry[]>();
+  for (const file of codemap.files) {
+    const key = file.module ?? 'Uncategorized';
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key)!.push(file);
+  }
+
+  for (const [, files] of groups) {
+    files.sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  const lines: string[] = [];
+  lines.push('# CODEMAP');
+  lines.push('');
+  lines.push(`Generated at: ${codemap.generatedAt}`);
+  lines.push('');
+
+  const groupNames = Array.from(groups.keys()).sort();
+
+  for (const groupName of groupNames) {
+    lines.push(`## Module: ${groupName}`);
+    lines.push('');
+
+    const files = groups.get(groupName)!;
+    let groupLineCount = 0;
+    const maxLines = Number.isFinite(markdownMaxPerGroup) ? markdownMaxPerGroup : Infinity;
+
+    for (const file of files) {
+      const fileLines: string[] = [];
+      fileLines.push(`- **${file.path}**`);
+      if (file.tags.length > 0) {
+        fileLines.push(`  - Tags: ${file.tags.join(', ')}`);
+      }
+      if (file.namedExports.length > 0) {
+        fileLines.push(`  - Exports: ${file.namedExports.join(', ')}`);
+      }
+      if (file.imports.length > 0) {
+        fileLines.push(`  - Imports: ${file.imports.join(', ')}`);
+      }
+      if (file.symbols.functions.length > 0) {
+        fileLines.push('  - Functions:');
+        for (const fn of file.symbols.functions) {
+          const details = [`    - ${fn.name} (line ${fn.line})${fn.exported ? ' [exported]' : ''}`];
+          if (!fast && fn.signature) {
+            details.push(`      - ${fn.signature}`);
+          }
+          fileLines.push(...details);
+        }
+      }
+      if (file.symbols.classes.length > 0) {
+        fileLines.push('  - Classes:');
+        for (const cls of file.symbols.classes) {
+          const clsDetails = [`    - ${cls.name} (line ${cls.line})${cls.exported ? ' [exported]' : ''}`];
+          if (!fast && cls.signature) {
+            clsDetails.push(`      - ${cls.signature}`);
+          }
+          if (cls.methods.length > 0) {
+            clsDetails.push('      - Methods:');
+            for (const method of cls.methods) {
+              const methodLine = `        - ${method.name} (line ${method.line})${method.exported ? ' [exported]' : ''}`;
+              clsDetails.push(methodLine);
+              if (!fast && method.signature) {
+                clsDetails.push(`          - ${method.signature}`);
+              }
+            }
+          }
+          fileLines.push(...clsDetails);
+        }
+      }
+
+      const newLinesCount = fileLines.length;
+      if (groupLineCount + newLinesCount > maxLines) {
+        lines.push('  - _Output truncated due to markdownMaxPerGroup limit._');
+        break;
+      }
+      lines.push(...fileLines);
+      groupLineCount += newLinesCount;
+      lines.push('');
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const config = await readConfig();
+  const { only, fast } = parseArgs();
+
+  const patterns = only ? [only] : config.include;
+
+  const filePaths = await globby(patterns, {
+    ignore: config.exclude,
+    gitignore: true,
+    absolute: true,
+  });
+
+  filePaths.sort((a, b) => a.localeCompare(b));
+  const filteredPaths = filePaths.filter((filePath) => /\.(ts|tsx|js|jsx)$/i.test(filePath));
+
+  const files: FileEntry[] = [];
+  for (const absolutePath of filteredPaths) {
+    const sourceText = await fs.readFile(absolutePath, 'utf8');
+    files.push(analyzeFile(absolutePath, sourceText, fast));
+  }
+
+  let finalFiles: FileEntry[] = files;
+  let previous: CodemapDocument | null = null;
+  const updatedPaths = new Set<string>(files.map((file) => file.path));
+
+  if (only) {
+    previous = await loadExistingCodemap();
+    if (previous) {
+      const map = new Map<string, FileEntry>();
+      const previousIndex = new Map(previous.files.map((file) => [file.path, file] as const));
+      for (const file of previous.files) {
+        map.set(file.path, file);
+      }
+      for (const file of files) {
+        map.set(file.path, file);
+      }
+
+      if (fast) {
+        for (const filePath of updatedPaths) {
+          const merged = map.get(filePath);
+          const prior = previousIndex.get(filePath);
+          if (!merged || !prior) {
+            continue;
+          }
+          merged.symbols.functions = merged.symbols.functions.map((fn) => {
+            if (!fn.signature) {
+              const previousFn = prior.symbols.functions.find(
+                (candidate) => candidate.name === fn.name && candidate.line === fn.line,
+              );
+              if (previousFn?.signature) {
+                fn.signature = previousFn.signature;
+              }
+            }
+            return fn;
+          });
+          merged.symbols.classes = merged.symbols.classes.map((cls) => {
+            if (!cls.signature) {
+              const previousCls = prior.symbols.classes.find(
+                (candidate) => candidate.name === cls.name && candidate.line === cls.line,
+              );
+              if (previousCls?.signature) {
+                cls.signature = previousCls.signature;
+              }
+            }
+            cls.methods = cls.methods.map((method) => {
+              if (!method.signature) {
+                const previousMethod = prior.symbols.methods.find(
+                  (candidate) =>
+                    candidate.name === method.name &&
+                    candidate.line === method.line &&
+                    candidate.className === method.className,
+                );
+                if (previousMethod?.signature) {
+                  method.signature = previousMethod.signature;
+                }
+              }
+              return method;
+            });
+            return cls;
+          });
+          merged.symbols.methods = merged.symbols.methods.map((method) => {
+            if (!method.signature) {
+              const previousMethod = prior.symbols.methods.find(
+                (candidate) =>
+                  candidate.name === method.name &&
+                  candidate.line === method.line &&
+                  candidate.className === method.className,
+              );
+              if (previousMethod?.signature) {
+                method.signature = previousMethod.signature;
+              }
+            }
+            return method;
+          });
+        }
+      }
+
+      finalFiles = Array.from(map.values()).sort((a, b) => a.path.localeCompare(b.path));
+    }
+  }
+
+  if (!previous) {
+    finalFiles = files.sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  const codemap: CodemapDocument = {
+    generatedAt: new Date().toISOString(),
+    options: { only, fast },
+    files: finalFiles,
+  };
+
+  const markdown = renderMarkdown(codemap, config.markdownMaxPerGroup ?? Infinity, fast);
+
+  await fs.writeFile(CODEMAP_PATH, JSON.stringify(codemap, null, 2));
+  await fs.writeFile(CODEMAP_MARKDOWN_PATH, markdown);
+
+  console.log(`Processed ${files.length} file(s).`);
+  if (only) {
+    console.log(`Filter: ${only}`);
+  }
+  if (fast) {
+    console.log('Fast mode enabled (signatures omitted).');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a configurable codemap generator that indexes package sources, tracks exports/symbol metadata, and supports fast incremental runs
- wire up repository defaults for codemap execution, including pnpm script, dev dependencies, and the Code Atlas contract
- produce the initial CODEMAP.md / codemap.json artifacts for the workspace using the new tool

## Testing
- pnpm i
- pnpm codemap
- pnpm codemap --only "packages/server/**" --fast
- pnpm codemap --only "packages/client/**" --fast
- pnpm codemap --only "packages/schemas/**" --fast

------
https://chatgpt.com/codex/tasks/task_e_68d6fcb753988333a75e3fc48a8d3b8f