### PR TITLE
Clean up client social moderation handling

### DIFF
--- a/codemap.json
+++ b/codemap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-27T12:07:08.702Z",
+  "generatedAt": "2025-09-27T12:17:21.293Z",
   "count": 50,
   "files": [
     {
@@ -70,8 +70,8 @@
     },
     {
       "path": "packages/client/src/App.tsx",
-      "size": 78442,
-      "checksum": "d8e3212fb77c1d210ed272fd647649cb094f9c3bac061ab1511e45a91e762de2",
+      "size": 78381,
+      "checksum": "ca0a2589a1b1a500be02837d948edc1bc5904d47435065b048cda6f937dd1003",
       "tags": [
         "ui",
         "realtime",
@@ -95,103 +95,103 @@
         "functions": [
           {
             "name": "adjustPosition",
-            "line": 167,
+            "line": 165,
             "exported": false,
             "signature": "(): void =>"
           },
           {
             "name": "renderTileSection",
-            "line": 251,
+            "line": 249,
             "exported": false,
             "signature": "( tile: GridTile, items: CanvasItem[], focusedItemId: string | null, ): JSX.Element => ( <section className=\"context-menu__section\" aria-label=\"Tile items\"> <header className=\"context-menu__header\"> <div> <span className=\"context-menu__title\">Felt ("
           },
           {
             "name": "renderTileMenu",
-            "line": 314,
+            "line": 312,
             "exported": false,
             "signature": "(payload: TileContextMenuState): JSX.Element => renderTileSection(payload.tile, payload.items, payload.focusedItemId)"
           },
           {
             "name": "renderOccupantMenu",
-            "line": 317,
+            "line": 315,
             "exported": false,
             "signature": "(payload: OccupantContextMenuState): JSX.Element =>"
           },
           {
             "name": "App",
-            "line": 488,
+            "line": 486,
             "exported": false,
             "signature": "(): JSX.Element =>"
           },
           {
             "name": "isEditableElement",
-            "line": 735,
+            "line": 733,
             "exported": false,
             "signature": "(element: Element | null): boolean =>"
           },
           {
             "name": "commitDraft",
-            "line": 748,
+            "line": 746,
             "exported": false,
             "signature": "(next: string) =>"
           },
           {
             "name": "handleGlobalKeyDown",
-            "line": 758,
+            "line": 756,
             "exported": false,
             "signature": "(event: KeyboardEvent): void =>"
           },
           {
             "name": "buildSlots",
-            "line": 972,
+            "line": 970,
             "exported": false,
             "signature": "(userId: string | null) =>"
           },
           {
             "name": "handleSlotChange",
-            "line": 989,
+            "line": 987,
             "exported": false,
             "signature": "(slotIndex: number, value: string) =>"
           },
           {
             "name": "handleSlotClear",
-            "line": 1013,
+            "line": 1011,
             "exported": false,
             "signature": "(slotIndex: number) =>"
           },
           {
             "name": "handleReadinessToggle",
-            "line": 1036,
+            "line": 1034,
             "exported": false,
             "signature": "(next: boolean) =>"
           },
           {
             "name": "parseTimestamp",
-            "line": 1236,
+            "line": 1234,
             "exported": false,
             "signature": "(value?: string | null): number =>"
           },
           {
             "name": "handlePointerDown",
-            "line": 1387,
+            "line": 1385,
             "exported": false,
             "signature": "(event: PointerEvent): void =>"
           },
           {
             "name": "handleKeyDown",
-            "line": 1406,
+            "line": 1404,
             "exported": false,
             "signature": "(event: KeyboardEvent): void =>"
           },
           {
             "name": "handleScroll",
-            "line": 1429,
+            "line": 1427,
             "exported": false,
             "signature": "(): void =>"
           },
           {
             "name": "handleMenuButtonClick",
-            "line": 2044,
+            "line": 2042,
             "exported": false,
             "signature": "(label: string): void =>"
           }
@@ -761,8 +761,8 @@
     },
     {
       "path": "packages/client/src/ws/useRealtimeConnection.ts",
-      "size": 74632,
-      "checksum": "9fa0d99da1d320bd76fc80945712659b9c28cda9ff568025bdb378fd17de6351",
+      "size": 74903,
+      "checksum": "a854b977fd192c34ea942a86b8cd9ad95e15bf74d68300c36fa96919ba71891d",
       "tags": [
         "websocket",
         "state",
@@ -1020,13 +1020,13 @@
           },
           {
             "name": "connect",
-            "line": 1479,
+            "line": 1483,
             "exported": false,
             "signature": "async () =>"
           },
           {
             "name": "detachListeners",
-            "line": 1536,
+            "line": 1540,
             "exported": false,
             "signature": "() =>"
           }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # FEATURES
 
-_Last updated: 2025-09-27T12:07:11.046Z_
+_Last updated: 2025-09-27T12:17:23.148Z_
 
 This file is generated from the codebase (module tags, routes, exports) to inventory what exists today. Status and notes may need a quick human touch.
 

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -4,24 +4,24 @@
      Keep bullets short. Update at the end of every session. -->
 
 ## Session Summary
-- 
+- Cleared client lint issues by pruning unused imports and tightening social moderation event handling.
 
 ## Next Actions (Top 3)
-1. 
-2. 
-3. 
+1. Decide on a supported TypeScript version or relax the lint config mismatch warning.
+2. Add coverage for social mute/report event reducers to prevent regressions.
+3. Continue hardening trade lifecycle UI flows (loading states, retries).
 
 ## Quick Wins (High Impact, Low Effort)
-- 
+- Surface a toast when a mute/report broadcast is ignored because it targets another user.
 
 ## Strategic Work (High Value, Higher Effort)
-- 
+- Align real-time moderation tooling with persistent server state and auditing requirements.
 
 ## Carry-Over (Finish Next)
-- 
+- Flesh out admin affordance toggles to cover all documented controls.
 
 ## Open Questions / Decisions Needed
-- 
+- Should client builds pin to an @typescript-eslint supported compiler release or override the warning?
 
 ## Session Log
-- YYYY-MM-DD HH:MM UTC — <short-sha> — one-line summary
+- 2025-09-27 12:15 UTC — 396e929 — Cleared client lint noise on social moderation events

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,8 +16,6 @@ import GridCanvas, { type CanvasItem, type CanvasOccupant } from './canvas/GridC
 import './styles.css';
 import {
   useRealtimeConnection,
-  type OccupantProfileSummary,
-  type TradeSessionBootstrap,
   type TradeLifecycleAcknowledgement,
 } from './ws/useRealtimeConnection';
 import type { GridTile } from './canvas/types';

--- a/packages/client/src/ws/useRealtimeConnection.ts
+++ b/packages/client/src/ws/useRealtimeConnection.ts
@@ -1209,12 +1209,15 @@ export const useRealtimeConnection = (): RealtimeConnectionState => {
             return;
           }
 
+          const broadcast: SocialMuteBroadcast = parsed.data;
           const sessionUser = sessionUserRef.current;
-          if (!sessionUser || parsed.data.mute.userId !== sessionUser.id) {
+          // Ignore mute broadcasts that are unrelated to the current user to
+          // avoid leaking another player's moderation state into this client.
+          if (!sessionUser || broadcast.mute.userId !== sessionUser.id) {
             return;
           }
 
-          mutedOccupantIdSetRef.current.add(parsed.data.mute.mutedUserId);
+          mutedOccupantIdSetRef.current.add(broadcast.mute.mutedUserId);
           setState((previous) => ({
             ...previous,
             mutedOccupantIds: Array.from(mutedOccupantIdSetRef.current),
@@ -1229,19 +1232,20 @@ export const useRealtimeConnection = (): RealtimeConnectionState => {
             return;
           }
 
+          const broadcast: SocialReportBroadcast = parsed.data;
           const sessionUser = sessionUserRef.current;
-          if (!sessionUser || parsed.data.report.reporterId !== sessionUser.id) {
+          if (!sessionUser || broadcast.report.reporterId !== sessionUser.id) {
             return;
           }
 
           const existingIndex = reportHistoryRef.current.findIndex(
-            (entry) => entry.id === parsed.data.report.id,
+            (entry) => entry.id === broadcast.report.id,
           );
           if (existingIndex >= 0) {
-            reportHistoryRef.current[existingIndex] = parsed.data.report;
+            reportHistoryRef.current[existingIndex] = broadcast.report;
           } else {
             reportHistoryRef.current = [
-              parsed.data.report,
+              broadcast.report,
               ...reportHistoryRef.current,
             ].slice(0, 50);
           }


### PR DESCRIPTION
## Summary
- remove unused realtime type imports from the client app entry point
- type the social mute/report handlers so they stay focused on the local user and clarify intent
- record the lint cleanup session and follow-ups in docs/NEXT

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7d40662a08333a0f1d57092ce5d08