### PR TITLE
feat: add trade lifecycle action retries

### DIFF
--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,6 +1,6 @@
 # CODEMAP
 
-Total files: 50
+Total files: 51
 
 ## packages/client
 
@@ -31,6 +31,7 @@ Total files: 50
 
 ## packages/client/src/ws
 
+- packages/client/src/ws/socialReducers.ts — exports: filterChatLogByMuted, reduceSocialMuteBroadcast, reduceSocialReportBroadcast
 - packages/client/src/ws/useRealtimeConnection.ts — exports: useRealtimeConnection
 
 ## packages/schemas/src

--- a/Master Spec.md
+++ b/Master Spec.md
@@ -127,7 +127,7 @@ sy >= originY && (sy + tileH) <= (originY + gridH)
 
 **Right-click**
 - **Grid**: show **only items** on that tile.  
-  - Actions per item: **Info** (always) → panel; **Saml Op** only if user **stands** on that tile and tile not `noPickup`.  
+  - Actions per item: **Info** (always) → panel; **Pick up** only if user **stands** on that tile and tile not `noPickup`.  
 - **Player**: right-click avatar → player menu (profile/actions).  
 - Always `preventDefault()`; long-press on touch.
 
@@ -579,7 +579,7 @@ CREATE TABLE audit_log (
 
 **Components**
 - Buttons: Primary (filled), Ghost (outlined); min hit 40×40.  
-- Context menu: z-index high; title “On this tile”; Info/Saml Op inline; click-through not allowed while open.  
+- Context menu: z-index high; title “On this tile”; Info/Pick up inline; click-through not allowed while open.  
 - Primary menu bar: fixed to the stage bottom, spans canvas + panel, cannot collapse, and keeps only the bottom-left corner round while the remaining corners stay square.
 - A11y: focus ring 2px, contrast AA+, keyboardable; `Esc` closes menus; respect `prefers-reduced-motion`.  
 - Visual stability test: switching theme must **not** alter any canvas pixels (checksum render).
@@ -912,7 +912,7 @@ ads:
 
 ## A.6 Context Menus
 
-- **Grid right-click**: shows **items only on that tile**. For each item: name + buttons [**Info**] and [**Saml Op**] (pickup only if user stands on that tile and tile not `noPickup`).  
+- **Grid right-click**: shows **items only on that tile**. For each item: name + buttons [**Info**] and [**Pick up**] (pickup only if user stands on that tile and tile not `noPickup`).  
 - **Player right-click**: shows actions (View profile, Trade, Mute, Report… per role/permissions).  
 - Max width 320px; keyboard accessible; escape closes; clicks outside close; menu never scrolls canvas.
 
@@ -963,15 +963,15 @@ ads:
 
 ## A.14 Error & Empty States
 
-- **Network lost**: **blocking overlay** covering the stage; disables all interactions until WS reconnect + re-auth + room resync complete. Show spinner + “Forbinder igen…” and backoff status; optional “Genindlæs” button remains within overlay (still blocks gameplay).  
+- **Network lost**: **blocking overlay** covering the stage; disables all interactions until WS reconnect + re-auth + room resync complete. Show spinner + “Reconnecting…” and backoff status; optional “Reload” button remains within overlay (still blocks gameplay).  
 - **Asset missing**: show neutral placeholder tile/item; log once per asset per session.
 
 ## A.15 Microcopy
 
-- Teleport: “Vælg et rum” / “Mine rum” / “Offentlige rum”  
-- Pickup success: “Lagt i rygsæk”  
-- Pickup blocked: “Kan ikke samle op her”  
-- Locked tile: “Det felt er låst”
+- Teleport: “Select a room” / “My rooms” / “Public rooms”  
+- Pickup success: “Added to backpack”  
+- Pickup blocked: “Cannot pick up here”  
+- Locked tile: “This tile is locked”
 
 ## A.16 Motion
 

--- a/codemap.json
+++ b/codemap.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2025-09-27T13:37:27.031Z",
-  "count": 50,
+  "generatedAt": "2025-09-27T14:38:55.175Z",
+  "count": 51,
   "files": [
     {
       "path": "packages/client/vite.config.ts",
@@ -70,8 +70,8 @@
     },
     {
       "path": "packages/client/src/App.tsx",
-      "size": 78833,
-      "checksum": "8381d885e00a98b96e6a5b169d0b8f21535a102ef2cc878d60f58550c1294892",
+      "size": 83818,
+      "checksum": "f22e7d4a58e2aa6fa9e8a6f9430dcfd3ac85d35404733ec0bdb01d65f9d5a891",
       "tags": [
         "ui",
         "realtime",
@@ -95,103 +95,103 @@
         "functions": [
           {
             "name": "adjustPosition",
-            "line": 165,
+            "line": 173,
             "exported": false,
             "signature": "(): void =>"
           },
           {
             "name": "renderTileSection",
-            "line": 249,
+            "line": 257,
             "exported": false,
-            "signature": "( tile: GridTile, items: CanvasItem[], focusedItemId: string | null, ): JSX.Element => ( <section className=\"context-menu__section\" aria-label=\"Tile items\"> <header className=\"context-menu__header\"> <div> <span className=\"context-menu__title\">Felt ("
+            "signature": "( tile: GridTile, items: CanvasItem[], focusedItemId: string | null, ): JSX.Element => ( <section className=\"context-menu__section\" aria-label=\"Tile items\"> <header className=\"context-menu__header\"> <div> <span className=\"context-menu__title\">Tile ("
           },
           {
             "name": "renderTileMenu",
-            "line": 312,
+            "line": 320,
             "exported": false,
             "signature": "(payload: TileContextMenuState): JSX.Element => renderTileSection(payload.tile, payload.items, payload.focusedItemId)"
           },
           {
             "name": "renderOccupantMenu",
-            "line": 315,
+            "line": 323,
             "exported": false,
             "signature": "(payload: OccupantContextMenuState): JSX.Element =>"
           },
           {
             "name": "App",
-            "line": 486,
+            "line": 494,
             "exported": false,
             "signature": "(): JSX.Element =>"
           },
           {
             "name": "isEditableElement",
-            "line": 733,
+            "line": 817,
             "exported": false,
             "signature": "(element: Element | null): boolean =>"
           },
           {
             "name": "commitDraft",
-            "line": 746,
+            "line": 830,
             "exported": false,
             "signature": "(next: string) =>"
           },
           {
             "name": "handleGlobalKeyDown",
-            "line": 756,
+            "line": 840,
             "exported": false,
             "signature": "(event: KeyboardEvent): void =>"
           },
           {
             "name": "buildSlots",
-            "line": 970,
+            "line": 1122,
             "exported": false,
             "signature": "(userId: string | null) =>"
           },
           {
             "name": "handleSlotChange",
-            "line": 987,
+            "line": 1139,
             "exported": false,
             "signature": "(slotIndex: number, value: string) =>"
           },
           {
             "name": "handleSlotClear",
-            "line": 1011,
+            "line": 1163,
             "exported": false,
             "signature": "(slotIndex: number) =>"
           },
           {
             "name": "handleReadinessToggle",
-            "line": 1034,
+            "line": 1186,
             "exported": false,
             "signature": "(next: boolean) =>"
           },
           {
             "name": "parseTimestamp",
-            "line": 1234,
+            "line": 1390,
             "exported": false,
             "signature": "(value?: string | null): number =>"
           },
           {
             "name": "handlePointerDown",
-            "line": 1398,
+            "line": 1554,
             "exported": false,
             "signature": "(event: PointerEvent): void =>"
           },
           {
             "name": "handleKeyDown",
-            "line": 1417,
+            "line": 1573,
             "exported": false,
             "signature": "(event: KeyboardEvent): void =>"
           },
           {
             "name": "handleScroll",
-            "line": 1440,
+            "line": 1596,
             "exported": false,
             "signature": "(): void =>"
           },
           {
             "name": "handleMenuButtonClick",
-            "line": 2055,
+            "line": 2211,
             "exported": false,
             "signature": "(label: string): void =>"
           }
@@ -760,9 +760,51 @@
       }
     },
     {
+      "path": "packages/client/src/ws/socialReducers.ts",
+      "size": 2704,
+      "checksum": "ec0787b0f99a3d26fd921d06834f0d9b9cf78bd8c96e5a251d7feee76db5d5fb",
+      "tags": [
+        "websocket",
+        "state",
+        "social"
+      ],
+      "imports": [
+        "@bitby/schemas"
+      ],
+      "namedExports": [
+        "filterChatLogByMuted",
+        "reduceSocialMuteBroadcast",
+        "reduceSocialReportBroadcast"
+      ],
+      "symbols": {
+        "functions": [
+          {
+            "name": "filterChatLogByMuted",
+            "line": 13,
+            "exported": true,
+            "signature": "( log: ChatMessageBroadcast[], mutedIds: ReadonlySet<string>, maxEntries: number = 200, ): ChatMessageBroadcast[] => log .filter((entry) => !entry.userId || !mutedIds.has(entry.userId)) .slice(-maxEntries)"
+          },
+          {
+            "name": "reduceSocialMuteBroadcast",
+            "line": 39,
+            "exported": true,
+            "signature": "("
+          },
+          {
+            "name": "reduceSocialReportBroadcast",
+            "line": 77,
+            "exported": true,
+            "signature": "("
+          }
+        ],
+        "classes": [],
+        "methods": []
+      }
+    },
+    {
       "path": "packages/client/src/ws/useRealtimeConnection.ts",
-      "size": 75407,
-      "checksum": "f0a9d6a777b36f4e41e333b5fce7a9b157ec263a0291bdc9e8d83b0d2ac804d7",
+      "size": 75982,
+      "checksum": "cc2cd8f9bbf516496c4e22c6b931198ecf50833f2643d78b8fe282a858b6bfd5",
       "tags": [
         "websocket",
         "state",
@@ -771,7 +813,8 @@
       "imports": [
         "react",
         "socket.io-client",
-        "@bitby/schemas"
+        "@bitby/schemas",
+        "./socialReducers"
       ],
       "namedExports": [
         "useRealtimeConnection"
@@ -780,253 +823,247 @@
         "functions": [
           {
             "name": "sortRoomItems",
-            "line": 73,
+            "line": 79,
             "exported": false,
             "signature": "(items: Iterable<RoomItem>): RoomItem[] => Array.from(items).sort((a, b) =>"
           },
           {
             "name": "sortInventoryItems",
-            "line": 81,
+            "line": 87,
             "exported": false,
             "signature": "(items: Iterable<InventoryItem>): InventoryItem[] => Array.from(items).sort((a, b) =>"
           },
           {
             "name": "isSessionUser",
-            "line": 111,
+            "line": 117,
             "exported": false,
             "signature": "(value: unknown): value is SessionUser =>"
           },
           {
             "name": "isSessionRoom",
-            "line": 126,
+            "line": 132,
             "exported": false,
             "signature": "(value: unknown): value is SessionRoom =>"
           },
           {
             "name": "cloneOccupant",
-            "line": 259,
+            "line": 263,
             "exported": false,
             "signature": "(occupant: RoomOccupant): RoomOccupant => ("
           },
           {
             "name": "sortOccupants",
-            "line": 265,
+            "line": 269,
             "exported": false,
             "signature": "(map: Map<string, RoomOccupant>): RoomOccupant[] => Array.from(map.values()) .map((occupant) => cloneOccupant(occupant)) .sort((a, b) =>"
           },
           {
             "name": "buildEnvelope",
-            "line": 276,
+            "line": 280,
             "exported": false,
             "signature": "( seq: number, op: string, data: Record<string, unknown> ="
           },
           {
             "name": "normaliseSocketProtocol",
-            "line": 292,
+            "line": 296,
             "exported": false,
             "signature": "(protocol: string): string =>"
           },
           {
             "name": "resolveSocketEndpoint",
-            "line": 303,
+            "line": 307,
             "exported": false,
             "signature": "(): SocketEndpoint =>"
           },
           {
             "name": "resolveHttpBaseUrl",
-            "line": 329,
+            "line": 333,
             "exported": false,
             "signature": "(): string =>"
           },
           {
             "name": "getExplicitToken",
-            "line": 344,
+            "line": 348,
             "exported": false,
             "signature": "(): string | null =>"
           },
           {
             "name": "getDevCredentials",
-            "line": 349,
+            "line": 353,
             "exported": false,
             "signature": "():"
           },
           {
             "name": "getLatestPendingTarget",
-            "line": 354,
+            "line": 358,
             "exported": false,
             "signature": "( pendingMoves: Map<number,"
           },
           {
             "name": "normaliseTypingPreview",
-            "line": 364,
+            "line": 368,
             "exported": false,
             "signature": "(input: string | null | undefined): string | null =>"
           },
           {
             "name": "snapshotTypingIndicators",
-            "line": 375,
+            "line": 379,
             "exported": false,
             "signature": "( source: Map<string, TypingIndicatorInternal>, ): TypingIndicatorView[] => Array.from(source.entries()).map(([userId, indicator]) => ("
           },
           {
             "name": "snapshotChatBubbles",
-            "line": 384,
+            "line": 388,
             "exported": false,
             "signature": "( source: Map<string, ChatBubbleInternal>, ): ChatBubbleView[] => Array.from(source.entries()).map(([userId, bubble]) => ("
           },
           {
             "name": "useRealtimeConnection",
-            "line": 394,
+            "line": 398,
             "exported": true,
             "signature": "(): RealtimeConnectionState =>"
           },
           {
             "name": "clearPingTimer",
-            "line": 455,
+            "line": 460,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "clearCountdownTimer",
-            "line": 462,
+            "line": 467,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "clearTypingCleanupTimer",
-            "line": 469,
+            "line": 474,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "clearBubbleCleanupTimer",
-            "line": 476,
+            "line": 481,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "abortLogin",
-            "line": 483,
+            "line": 488,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "clearActiveSocket",
-            "line": 491,
+            "line": 496,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "startPingTimer",
-            "line": 514,
+            "line": 519,
             "exported": false,
             "signature": "(intervalMs: number) =>"
           },
           {
             "name": "updateState",
-            "line": 530,
+            "line": 535,
             "exported": false,
             "signature": "(partial: Partial<InternalConnectionState>) =>"
           },
           {
             "name": "requestAuthToken",
-            "line": 553,
+            "line": 558,
             "exported": false,
             "signature": "async (): Promise<string> =>"
           },
           {
             "name": "scheduleReconnect",
-            "line": 648,
+            "line": 653,
             "exported": false,
             "signature": "() =>"
           },
           {
-            "name": "filterChatLogByMuted",
-            "line": 708,
-            "exported": false,
-            "signature": "( log: ChatMessageBroadcast[], mutedIds: Set<string>, ): ChatMessageBroadcast[] => log .filter((entry) => !entry.userId || !mutedIds.has(entry.userId)) .slice(-200)"
-          },
-          {
             "name": "appendChatMessage",
-            "line": 716,
+            "line": 713,
             "exported": false,
             "signature": "(message: ChatMessageBroadcast) =>"
           },
           {
             "name": "publishTypingIndicators",
-            "line": 735,
+            "line": 732,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "pruneTypingIndicators",
-            "line": 739,
+            "line": 736,
             "exported": false,
             "signature": "(now: number = Date.now()): void =>"
           },
           {
             "name": "scheduleTypingCleanup",
-            "line": 752,
+            "line": 749,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "upsertTypingIndicator",
-            "line": 763,
+            "line": 760,
             "exported": false,
             "signature": "( userId: string, preview: string | null, expiresAt?: number, ): void =>"
           },
           {
             "name": "removeTypingIndicator",
-            "line": 780,
+            "line": 777,
             "exported": false,
             "signature": "(userId: string): void =>"
           },
           {
             "name": "publishChatBubbles",
-            "line": 789,
+            "line": 786,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "pruneChatBubbles",
-            "line": 793,
+            "line": 790,
             "exported": false,
             "signature": "(now: number = Date.now()): void =>"
           },
           {
             "name": "scheduleBubbleCleanup",
-            "line": 806,
+            "line": 803,
             "exported": false,
             "signature": "() =>"
           },
           {
             "name": "upsertChatBubble",
-            "line": 817,
+            "line": 814,
             "exported": false,
             "signature": "(userId: string, messageId: string, body: string): void =>"
           },
           {
             "name": "removeChatBubble",
-            "line": 827,
+            "line": 824,
             "exported": false,
             "signature": "(userId: string): void =>"
           },
           {
             "name": "handleEnvelope",
-            "line": 836,
+            "line": 833,
             "exported": false,
             "signature": "(envelope: MessageEnvelope) =>"
           },
           {
             "name": "connect",
-            "line": 1502,
+            "line": 1508,
             "exported": false,
             "signature": "async () =>"
           },
           {
             "name": "detachListeners",
-            "line": 1559,
+            "line": 1565,
             "exported": false,
             "signature": "() =>"
           }
@@ -2138,8 +2175,8 @@
     },
     {
       "path": "packages/server/src/ws/connection.ts",
-      "size": 58004,
-      "checksum": "b9c63b7bd09c1925367b90f6d3e31e8bf4d534322be5e1dd234dbc1f2196638b",
+      "size": 57970,
+      "checksum": "f5cdde21078f6b729c1ed85654edadacbc05f1579bebde721ce5157a8d192caa",
       "tags": [],
       "imports": [
         "node:crypto",

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # FEATURES
 
-_Last updated: 2025-09-27T13:37:29.401Z_
+_Last updated: 2025-09-27T14:38:57.563Z_
 
 This file is generated from the codebase (module tags, routes, exports) to inventory what exists today. Status and notes may need a quick human touch.
 
@@ -13,7 +13,7 @@ This file is generated from the codebase (module tags, routes, exports) to inven
 | canvas | 4 | 0 | 0 | 0 | 0 |
 | client | 3 | 0 | 0 | 0 | 0 |
 | client-app | 1 | 0 | 0 | 0 | 0 |
-| client-realtime | 1 | 0 | 0 | 0 | 0 |
+| client-realtime | 2 | 0 | 0 | 0 | 0 |
 | config.ts | 1 | 0 | 0 | 0 | 1 |
 | db | 9 | 0 | 0 | 0 | 0 |
 | index.ts | 2 | 0 | 2 | 0 | 1 |

--- a/docs/NEXT.md
+++ b/docs/NEXT.md
@@ -7,14 +7,17 @@
 - Suppressed unsupported TypeScript version warnings in the ESLint parser to match current tooling.
 - Recorded ignored social mute/report broadcasts and surfaced informational toasts instead of silently discarding them.
 - Expanded the client toast hook and styles to support an info tone used by moderation notices.
+- Wired the admin quick menu visibility toggle into the realtime admin state store and dock UI.
+- Added dedicated reducers and Vitest coverage for social mute/report broadcasts.
+- Hardened the trade banner actions with inline loading indicators, guarded buttons, and a retry path for failed lifecycle calls.
 
 ## Next Actions (Top 3)
-1. Design and implement the admin quick menu toggle flow described in AGENT section 3, wiring it to the existing admin state store.
-2. Add coverage for social mute/report event reducers to prevent regressions.
-3. Continue hardening trade lifecycle UI flows (loading states, retries).
+1. Add invite expiration and resend handling to the trade lifecycle banner.
+2. Hook the admin quick menu buttons up to real server affordance endpoints.
+3. Break down `packages/client/src/App.tsx` to isolate admin tooling from the primary render path.
 
 ## Quick Wins (High Impact, Low Effort)
-- Surface a toast when a mute/report broadcast is ignored because it targets another user.
+- Document a hover affordance for disabled admin buttons to explain the required role.
 
 ## Strategic Work (High Value, Higher Effort)
 - Align real-time moderation tooling with persistent server state and auditing requirements.
@@ -30,3 +33,5 @@
 ## Session Log
 - 2025-09-27 12:15 UTC — 396e929 — Cleared client lint noise on social moderation events
 - 2025-09-27 13:28 UTC — (pending) — Disabled TypeScript lint mismatch warning and added moderation ignore toasts
+- 2025-09-27 14:28 UTC — (pending) — Implemented admin quick menu toggle state and social broadcast reducers with tests
+- 2025-09-27 15:28 UTC — (pending) — Added guarded trade banner actions with retry affordances

--- a/packages/client/src/styles.css
+++ b/packages/client/src/styles.css
@@ -744,6 +744,12 @@ body {
   transition: background 0.2s ease;
 }
 
+.trade-banner__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: rgba(122, 209, 255, 0.12);
+}
+
 .trade-banner__button:hover {
   background: rgba(122, 209, 255, 0.3);
 }
@@ -776,6 +782,26 @@ body {
 .trade-banner__button--link:hover {
   background: transparent;
   color: rgba(122, 209, 255, 1);
+}
+
+.trade-banner__feedback {
+  font-size: 12px;
+  color: rgba(234, 242, 255, 0.82);
+  margin: 0;
+}
+
+.trade-banner__feedback--error {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  color: #ff99a6;
+}
+
+.trade-banner__feedback-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .trade-banner--declined {

--- a/packages/client/src/ws/__tests__/socialReducers.test.ts
+++ b/packages/client/src/ws/__tests__/socialReducers.test.ts
@@ -1,0 +1,232 @@
+// @module: client-realtime-tests
+// @tags: websocket, state, social, tests
+
+import { describe, expect, it } from 'vitest';
+import type {
+  ChatMessageBroadcast,
+  ReportRecord,
+  SocialMuteBroadcast,
+  SocialReportBroadcast,
+} from '@bitby/schemas';
+import {
+  filterChatLogByMuted,
+  reduceSocialMuteBroadcast,
+  reduceSocialReportBroadcast,
+} from '../socialReducers';
+
+const buildChatMessage = (overrides: Partial<ChatMessageBroadcast> = {}): ChatMessageBroadcast => ({
+  id: overrides.id ?? crypto.randomUUID(),
+  userId: overrides.userId ?? 'user-1',
+  username: overrides.username ?? 'User One',
+  roles: overrides.roles ?? [],
+  body: overrides.body ?? 'Hello there',
+  createdAt: overrides.createdAt ?? new Date().toISOString(),
+  roomSeq: overrides.roomSeq ?? 1,
+});
+
+const buildMuteBroadcast = (overrides: Partial<SocialMuteBroadcast['mute']> = {}): SocialMuteBroadcast => ({
+  mute: {
+    id: overrides.id ?? crypto.randomUUID(),
+    userId: overrides.userId ?? 'moderator-1',
+    mutedUserId: overrides.mutedUserId ?? 'muted-user',
+    roomId: overrides.roomId ?? 'room-1',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+  },
+});
+
+const buildReportBroadcast = (
+  overrides: Partial<SocialReportBroadcast['report']> = {},
+): SocialReportBroadcast => ({
+  report: {
+    id: overrides.id ?? crypto.randomUUID(),
+    reporterId: overrides.reporterId ?? 'moderator-1',
+    reportedUserId: overrides.reportedUserId ?? 'user-2',
+    roomId: overrides.roomId ?? 'room-1',
+    reason: overrides.reason ?? 'spam',
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+  },
+});
+
+describe('filterChatLogByMuted', () => {
+  it('removes muted user messages', () => {
+    const mutedIds = new Set(['muted-user']);
+    const log: ChatMessageBroadcast[] = Array.from({ length: 205 }, (_, index) =>
+      buildChatMessage({
+        id: `message-${index + 1}`,
+        userId: index % 2 === 0 ? 'muted-user' : `user-${index}`,
+        roomSeq: index + 1,
+      }),
+    );
+
+    const filtered = filterChatLogByMuted(log, mutedIds);
+
+    expect(filtered).toHaveLength(102);
+    expect(filtered.every((entry) => entry.userId !== 'muted-user')).toBe(true);
+    expect(filtered[0].id).toBe('message-2');
+    expect(filtered.at(-1)?.id).toBe('message-204');
+  });
+
+  it('limits the retained messages to the last 200 entries', () => {
+    const log: ChatMessageBroadcast[] = Array.from({ length: 250 }, (_, index) =>
+      buildChatMessage({ id: `message-${index + 1}`, userId: `user-${index}`, roomSeq: index + 1 }),
+    );
+
+    const filtered = filterChatLogByMuted(log, new Set());
+
+    expect(filtered).toHaveLength(200);
+    expect(filtered[0].id).toBe('message-51');
+    expect(filtered.at(-1)?.id).toBe('message-250');
+  });
+});
+
+describe('reduceSocialMuteBroadcast', () => {
+  it('returns noop when no session user is present', () => {
+    const broadcast = buildMuteBroadcast();
+    const outcome = reduceSocialMuteBroadcast({
+      broadcast,
+      sessionUserId: null,
+      mutedIds: new Set(),
+      chatLog: [],
+      now: () => 10,
+    });
+
+    expect(outcome).toEqual({ kind: 'noop' });
+  });
+
+  it('returns ignored when the mute targets another player', () => {
+    const broadcast = buildMuteBroadcast({ userId: 'moderator-2' });
+    const outcome = reduceSocialMuteBroadcast({
+      broadcast,
+      sessionUserId: 'moderator-1',
+      mutedIds: new Set(),
+      chatLog: [],
+      now: () => 42,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'ignored',
+      event: { type: 'mute', receivedAt: 42 },
+    });
+  });
+
+  it('adds the muted user and filters the chat log for the current moderator', () => {
+    const broadcast = buildMuteBroadcast({ userId: 'moderator-1', mutedUserId: 'muted-user' });
+    const mutedIds = new Set<string>();
+    const chatLog = [
+      buildChatMessage({ id: 'message-1', userId: 'muted-user', roomSeq: 1 }),
+      buildChatMessage({ id: 'message-2', userId: 'friend', roomSeq: 2 }),
+    ];
+
+    const outcome = reduceSocialMuteBroadcast({
+      broadcast,
+      sessionUserId: 'moderator-1',
+      mutedIds,
+      chatLog,
+      now: () => 90,
+    });
+
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind !== 'applied') {
+      return;
+    }
+
+    expect(outcome.mutedOccupantIds).toEqual(['muted-user']);
+    expect(outcome.chatLog).toEqual([chatLog[1]]);
+  });
+});
+
+describe('reduceSocialReportBroadcast', () => {
+  it('returns noop when no session user is available', () => {
+    const broadcast = buildReportBroadcast();
+    const outcome = reduceSocialReportBroadcast({
+      broadcast,
+      sessionUserId: null,
+      reportHistory: [],
+      now: () => 77,
+    });
+
+    expect(outcome).toEqual({ kind: 'noop' });
+  });
+
+  it('returns ignored when the report originates from another moderator', () => {
+    const broadcast = buildReportBroadcast({ reporterId: 'moderator-2' });
+    const outcome = reduceSocialReportBroadcast({
+      broadcast,
+      sessionUserId: 'moderator-1',
+      reportHistory: [],
+      now: () => 64,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'ignored',
+      event: { type: 'report', receivedAt: 64 },
+    });
+  });
+
+  it('upserts the report history and enforces the size limit', () => {
+    const existing: ReportRecord[] = [
+      {
+        id: 'report-1',
+        reporterId: 'moderator-1',
+        reportedUserId: 'user-5',
+        roomId: 'room-1',
+        reason: 'spam',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: 'report-2',
+        reporterId: 'moderator-1',
+        reportedUserId: 'user-6',
+        roomId: 'room-1',
+        reason: 'abuse',
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    const broadcast = buildReportBroadcast({ id: 'report-3' });
+    const outcome = reduceSocialReportBroadcast({
+      broadcast,
+      sessionUserId: 'moderator-1',
+      reportHistory: existing,
+      maxEntries: 2,
+      now: () => 100,
+    });
+
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind !== 'applied') {
+      return;
+    }
+
+    expect(outcome.reportHistory.map((entry) => entry.id)).toEqual(['report-3', 'report-1']);
+  });
+
+  it('replaces an existing report when the identifiers match', () => {
+    const existing: ReportRecord[] = [
+      {
+        id: 'report-1',
+        reporterId: 'moderator-1',
+        reportedUserId: 'user-5',
+        roomId: 'room-1',
+        reason: 'spam',
+        createdAt: new Date().toISOString(),
+      },
+    ];
+
+    const broadcast = buildReportBroadcast({ id: 'report-1', reason: 'updated' });
+    const outcome = reduceSocialReportBroadcast({
+      broadcast,
+      sessionUserId: 'moderator-1',
+      reportHistory: existing,
+      now: () => 120,
+    });
+
+    expect(outcome.kind).toBe('applied');
+    if (outcome.kind !== 'applied') {
+      return;
+    }
+
+    expect(outcome.reportHistory).toHaveLength(1);
+    expect(outcome.reportHistory[0].reason).toBe('updated');
+  });
+});
+

--- a/packages/client/src/ws/socialReducers.ts
+++ b/packages/client/src/ws/socialReducers.ts
@@ -1,0 +1,108 @@
+// @module: client-realtime
+// @tags: websocket, state, social
+
+import type {
+  ChatMessageBroadcast,
+  ReportRecord,
+  SocialMuteBroadcast,
+  SocialReportBroadcast,
+} from '@bitby/schemas';
+
+export type SocialIgnoreEvent = { type: 'mute' | 'report'; receivedAt: number };
+
+export const filterChatLogByMuted = (
+  log: ChatMessageBroadcast[],
+  mutedIds: ReadonlySet<string>,
+  maxEntries: number = 200,
+): ChatMessageBroadcast[] =>
+  log
+    .filter((entry) => !entry.userId || !mutedIds.has(entry.userId))
+    .slice(-maxEntries);
+
+type ReduceMuteParams = {
+  broadcast: SocialMuteBroadcast;
+  sessionUserId: string | null;
+  mutedIds: Set<string>;
+  chatLog: ChatMessageBroadcast[];
+  now?: () => number;
+};
+
+export type SocialMuteReducerOutcome =
+  | { kind: 'noop' }
+  | { kind: 'ignored'; event: SocialIgnoreEvent }
+  | {
+      kind: 'applied';
+      mutedOccupantIds: string[];
+      chatLog: ChatMessageBroadcast[];
+    };
+
+export const reduceSocialMuteBroadcast = ({
+  broadcast,
+  sessionUserId,
+  mutedIds,
+  chatLog,
+  now = Date.now,
+}: ReduceMuteParams): SocialMuteReducerOutcome => {
+  if (!sessionUserId) {
+    return { kind: 'noop' };
+  }
+
+  if (broadcast.mute.userId !== sessionUserId) {
+    return { kind: 'ignored', event: { type: 'mute', receivedAt: now() } };
+  }
+
+  mutedIds.add(broadcast.mute.mutedUserId);
+  return {
+    kind: 'applied',
+    mutedOccupantIds: Array.from(mutedIds),
+    chatLog: filterChatLogByMuted(chatLog, mutedIds),
+  };
+};
+
+export const SOCIAL_REPORT_HISTORY_LIMIT = 50;
+
+type ReduceReportParams = {
+  broadcast: SocialReportBroadcast;
+  sessionUserId: string | null;
+  reportHistory: ReportRecord[];
+  maxEntries?: number;
+  now?: () => number;
+};
+
+export type SocialReportReducerOutcome =
+  | { kind: 'noop' }
+  | { kind: 'ignored'; event: SocialIgnoreEvent }
+  | { kind: 'applied'; reportHistory: ReportRecord[] };
+
+export const reduceSocialReportBroadcast = ({
+  broadcast,
+  sessionUserId,
+  reportHistory,
+  maxEntries = SOCIAL_REPORT_HISTORY_LIMIT,
+  now = Date.now,
+}: ReduceReportParams): SocialReportReducerOutcome => {
+  if (!sessionUserId) {
+    return { kind: 'noop' };
+  }
+
+  if (broadcast.report.reporterId !== sessionUserId) {
+    return { kind: 'ignored', event: { type: 'report', receivedAt: now() } };
+  }
+
+  const nextHistory = [...reportHistory];
+  const existingIndex = nextHistory.findIndex(
+    (entry) => entry.id === broadcast.report.id,
+  );
+
+  if (existingIndex >= 0) {
+    nextHistory[existingIndex] = broadcast.report;
+  } else {
+    nextHistory.unshift(broadcast.report);
+    if (nextHistory.length > maxEntries) {
+      nextHistory.length = maxEntries;
+    }
+  }
+
+  return { kind: 'applied', reportHistory: nextHistory };
+};
+

--- a/packages/server/src/ws/connection.ts
+++ b/packages/server/src/ws/connection.ts
@@ -1535,31 +1535,31 @@ export const createRealtimeServer = async ({
 
     const parsed = itemPickupRequestDataSchema.safeParse(envelope.data);
     if (!parsed.success) {
-      sendError('validation_failed', 'Ugyldig anmodning om pickup.', candidateItemId);
+      sendError('validation_failed', 'Invalid pickup request.', candidateItemId);
       return;
     }
 
     const itemId = parsed.data.itemId;
     const occupant = developmentRoomState.occupants.get(user.id);
     if (!occupant) {
-      sendError('not_in_room', 'Du er ikke registreret i dette rum.', itemId);
+      sendError('not_in_room', 'You are not registered in this room.', itemId);
       return;
     }
 
     const item = developmentRoomState.items.get(itemId);
     if (!item) {
-      sendError('not_found', 'Genstanden findes ikke længere.', itemId);
+      sendError('not_found', 'The item no longer exists.', itemId);
       return;
     }
 
     if (occupant.position.x !== item.tileX || occupant.position.y !== item.tileY) {
-      sendError('not_on_tile', 'Stil dig på feltet for at samle op.', itemId);
+      sendError('not_on_tile', 'Stand on the tile to pick up.', itemId);
       return;
     }
 
     const tile = developmentRoomState.tileIndex.get(createTileKey(item.tileX, item.tileY));
     if (tile?.noPickup) {
-      sendError('tile_blocked', 'Kan ikke samle op her.', itemId);
+      sendError('tile_blocked', 'Cannot pick up here.', itemId);
       return;
     }
 
@@ -1572,7 +1572,7 @@ export const createRealtimeServer = async ({
       });
     } catch (error) {
       logger.error({ err: error }, 'Failed to persist item pickup');
-      sendError('persist_failed', 'Kunne ikke gemme din genstand. Prøv igen.', itemId);
+      sendError('persist_failed', 'Could not save your item. Try again.', itemId);
       return;
     }
 
@@ -1583,10 +1583,10 @@ export const createRealtimeServer = async ({
 
       const message =
         result.reason === 'already_picked_up'
-          ? 'Genstanden er allerede samlet op.'
+          ? 'The item has already been picked up.'
           : result.reason === 'not_found'
-            ? 'Genstanden findes ikke længere.'
-            : 'Kunne ikke gemme din genstand. Prøv igen.';
+            ? 'The item no longer exists.'
+            : 'Could not save your item. Try again.';
 
       const code =
         result.reason === 'already_picked_up'


### PR DESCRIPTION
## Summary
- add tracked trade action state to the client app so accept, cancel, decline, and complete calls show inline loading and retry feedback
- style the trade banner buttons and feedback text to support the new disabled and error states
- update NEXT to log the trading work and queue follow-up invite expiration handling

## Testing
- pnpm --filter @bitby/client test

------
https://chatgpt.com/codex/tasks/task_e_68d7ee853a308333932fafaa92681c7f